### PR TITLE
fix(ui): normalize selection feedback from show_error to show_message

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -515,7 +515,7 @@ impl UIApp {
                         }
                     }
                 } else {
-                    self.show_error("No buffer to close".to_string());
+                    self.show_message("No buffer to close".to_string());
                     Ok(true)
                 }
             }
@@ -575,7 +575,7 @@ impl UIApp {
                                 });
                             }
                         } else {
-                            self.show_error("No playlist selected for deletion".to_string());
+                            self.show_message("No playlist selected for deletion".to_string());
                         }
                     }
                     return Ok(true);
@@ -595,7 +595,7 @@ impl UIApp {
                             input: String::new(),
                         });
                     } else {
-                        self.show_error("No podcast selected for deletion".to_string());
+                        self.show_message("No podcast selected for deletion".to_string());
                     }
                 } else {
                     self.show_error("Podcast list not available".to_string());
@@ -647,7 +647,7 @@ impl UIApp {
                         // Trigger async refresh
                         self.trigger_async_refresh_single(podcast_id);
                     } else {
-                        self.show_error("No podcast selected for refresh".to_string());
+                        self.show_message("No podcast selected for refresh".to_string());
                     }
                 } else {
                     self.show_error("Podcast list not available".to_string());
@@ -747,7 +747,7 @@ impl UIApp {
                             Err(e) => self.show_error(format!("Could not list playlists: {}", e)),
                         }
                     } else {
-                        self.show_error("No episode selected".to_string());
+                        self.show_message("No episode selected".to_string());
                     }
                 }
                 Ok(true)
@@ -819,7 +819,7 @@ impl UIApp {
                         // Trigger async hard refresh
                         self.trigger_async_hard_refresh_single(podcast_id);
                     } else {
-                        self.show_error("No podcast selected for hard refresh".to_string());
+                        self.show_message("No podcast selected for hard refresh".to_string());
                     }
                 } else {
                     self.show_error("Podcast list not available".to_string());
@@ -1677,7 +1677,7 @@ impl UIApp {
                             }
                         }
                     } else {
-                        self.show_error("No buffer to close".to_string());
+                        self.show_message("No buffer to close".to_string());
                         Ok(true)
                     }
                 }
@@ -3657,7 +3657,7 @@ impl UIApp {
                 self.pending_bulk_deletion = false;
                 self.trigger_async_delete_all_downloads();
             } else {
-                self.show_error("No deletion pending".to_string());
+                self.show_message("No deletion pending".to_string());
             }
         } else if input.to_lowercase() == "n" || input.to_lowercase() == "no" {
             // Cancel deletion


### PR DESCRIPTION
## Problem

Several paths in `src/ui/app.rs` used `show_error(...)` for conditions that are not errors — they are informational states (nothing is selected, nothing is pending). This caused the minibuffer to display these messages in error styling (red) unnecessarily, misleading users into thinking something had gone wrong.

## Guideline Applied

- `show_message` — informational feedback: nothing selected, state changes, mode changes
- `show_error` — actual failures: storage errors, network errors, invalid input

## Changes

**7 `show_error` → `show_message` call sites in `src/ui/app.rs`:**

| Line | Message | Notes |
|------|---------|-------|
| ~518 | "No buffer to close" | Extended scope — same informational pattern |
| ~578 | "No playlist selected for deletion" | |
| ~598 | "No podcast selected for deletion" | |
| ~650 | "No podcast selected for refresh" | |
| ~750 | "No episode selected" | AddToPlaylist handler |
| ~822 | "No podcast selected for hard refresh" | |
| ~1680 | "No buffer to close" | Extended scope — second site of same message |
| ~3660 | "No deletion pending" | Extended scope — same informational pattern |

### Extended Scope (lines ~518, ~1680, ~3660)

Lines ~518 and ~1680 ("No buffer to close") and ~3660 ("No deletion pending") were not in the original issue report but follow the exact same "nothing selected/available" informational pattern. They were included to make the fix consistent across all such sites in the file.

## What Was NOT Changed

All `show_error` calls that represent actual failures were left untouched:
- `"Podcast list not available"`
- Storage errors (`"Cannot close buffer: {}"` etc.)
- Network errors
- Invalid input errors

## Testing

- `cargo test`: 213 unit tests + integration tests passed (pre-existing `test_opml_local_file` failure is unrelated — missing test fixture file)
- `cargo clippy`: Pre-existing warnings only — no new issues introduced
- `cargo fmt --check`: No formatting issues in `app.rs`

Closes #64