### PR TITLE
fix(storage): remove unsafe PodcastId::as_str() that leaked memory

### DIFF
--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -29,14 +29,6 @@ impl PodcastId {
         let uuid = Uuid::from_u64_pair(hash, hash);
         Self(uuid)
     }
-
-    /// Get the string representation of the ID
-    pub fn as_str(&self) -> &str {
-        // This is a workaround - we return the Display formatted string
-        // For a proper implementation, we'd store the string separately
-        // or use a different ID type
-        unsafe { std::mem::transmute(Box::leak(Box::new(self.0.to_string())).as_str()) }
-    }
 }
 
 impl Default for PodcastId {


### PR DESCRIPTION
## Bug

PodcastId::as_str() in src/storage/models.rs used Box::leak and std::mem::transmute to forge a &str lifetime, leaking a heap allocation on every call. This is both unsound and a memory leak.

## Why it is safe to remove

A thorough audit of the entire codebase (src/ and tests/) confirms zero callers of PodcastId::as_str(). The method was dead code.

Callers that need a string representation can use .to_string() or the existing Display impl (format!('{id}')).

## Change

Deleted the as_str() method (doc comment + fn body) from PodcastId. No other files were modified.

Closes #63