### PR TITLE
chore: backfill winget manifests for v1.6.0, v1.7.0, v1.8.0

### DIFF
--- a/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.installer.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.6.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.6.0-windows-aarch64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.6.0/podcast-tui-v1.6.0-windows-aarch64.zip
+  InstallerSha256: 727041B563B96C163ABF1B42BA8D440091A2CAD9DE27C13FE86F930081C529FF
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.6.0-windows-x86_64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.6.0/podcast-tui-v1.6.0-windows-x86_64.zip
+  InstallerSha256: 23E20CC9B4DCEDED55166CD3A57BCDD8B721064517F143D41C3257EB663A866E
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-02-16

--- a/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.locale.en-US.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: lqdev
+PublisherUrl: https://github.com/lqdev
+PublisherSupportUrl: https://github.com/lqdev/podcast-tui/issues
+PackageName: PodcastTUI
+PackageUrl: https://github.com/lqdev/podcast-tui
+License: MIT License
+ShortDescription: A Terminal User Interface for Podcast Management
+ReleaseNotesUrl: https://github.com/lqdev/podcast-tui/releases/tag/v1.6.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/lqdev/podcast-tui/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.6.0/lqdev.PodcastTUI.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.installer.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.7.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.7.0-windows-aarch64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.7.0/podcast-tui-v1.7.0-windows-aarch64.zip
+  InstallerSha256: 9A3B2021FA57A9217979F3FC0739B245641E23C98629CA6CF4BF01530746DDAE
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.7.0-windows-x86_64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.7.0/podcast-tui-v1.7.0-windows-x86_64.zip
+  InstallerSha256: 6EAA8FEABF1BE8571AF393070B3B9A34A23BA9F19E10C71E123E919810C6AFDE
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-02-17

--- a/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.locale.en-US.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: lqdev
+PublisherUrl: https://github.com/lqdev
+PublisherSupportUrl: https://github.com/lqdev/podcast-tui/issues
+PackageName: PodcastTUI
+PackageUrl: https://github.com/lqdev/podcast-tui
+License: MIT License
+ShortDescription: A Terminal User Interface for Podcast Management
+ReleaseNotesUrl: https://github.com/lqdev/podcast-tui/releases/tag/v1.7.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/lqdev/podcast-tui/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.7.0/lqdev.PodcastTUI.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.installer.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.8.0
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.8.0-windows-aarch64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.8.0/podcast-tui-v1.8.0-windows-aarch64.zip
+  InstallerSha256: 85259B5E861AE38733C27ED6ABD1E0B355C5EFC37B3AAA01FC55AA7B48D42792
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: podcast-tui-v1.8.0-windows-x86_64\podcast-tui.exe
+    PortableCommandAlias: podcast-tui
+  InstallerUrl: https://github.com/lqdev/podcast-tui/releases/download/v1.8.0/podcast-tui-v1.8.0-windows-x86_64.zip
+  InstallerSha256: EDE3249894E7089206D0E2D088B6C49CA08238A402FACA3D820493B618C763C9
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2026-02-19

--- a/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.locale.en-US.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.8.0
+PackageLocale: en-US
+Publisher: lqdev
+PublisherUrl: https://github.com/lqdev
+PublisherSupportUrl: https://github.com/lqdev/podcast-tui/issues
+PackageName: PodcastTUI
+PackageUrl: https://github.com/lqdev/podcast-tui
+License: MIT License
+ShortDescription: A Terminal User Interface for Podcast Management
+ReleaseNotesUrl: https://github.com/lqdev/podcast-tui/releases/tag/v1.8.0
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/lqdev/podcast-tui/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.yaml
+++ b/manifests/l/lqdev/PodcastTUI/1.8.0/lqdev.PodcastTUI.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: lqdev.PodcastTUI
+PackageVersion: 1.8.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
## Summary

Closes #54 (partial — winget manifest backfill)

### Changes

Adds the three missing winget manifest directories:
- \manifests/l/lqdev/PodcastTUI/1.6.0/\ (3 YAML files)
- \manifests/l/lqdev/PodcastTUI/1.7.0/\ (3 YAML files)
- \manifests/l/lqdev/PodcastTUI/1.8.0/\ (3 YAML files)

Only \1.5.0\ existed before. Manifests were created manually (instead of via \wingetcreate update\) because \lqdev.PodcastTUI\ is not yet in \microsoft/winget-pkgs\ — \wingetcreate update\ requires the package to exist there first.

### SHA256 Hashes (computed by downloading release artifacts)

| Version | Arch | SHA256 |
|---------|------|--------|
| 1.6.0 | arm64 | \727041B563B96C163ABF1B42BA8D440091A2CAD9DE27C13FE86F930081C529FF\ |
| 1.6.0 | x64 | \23E20CC9B4DCEDED55166CD3A57BCDD8B721064517F143D41C3257EB663A866E\ |
| 1.7.0 | arm64 | \9A3B2021FA57A9217979F3FC0739B245641E23C98629CA6CF4BF01530746DDAE\ |
| 1.7.0 | x64 | \6EAA8FEABF1BE8571AF393070B3B9A34A23BA9F19E10C71E123E919810C6AFDE\ |
| 1.8.0 | arm64 | \85259B5E861AE38733C27ED6ABD1E0B355C5EFC37B3AAA01FC55AA7B48D42792\ |
| 1.8.0 | x64 | \EDE3249894E7089206D0E2D088B6C49CA08238A402FACA3D820493B618C763C9\ |

### Validation
- \winget validate\ passed for all three versions ✅
- File structure matches existing 1.5.0 layout ✅
- Artifact naming follows clean semver pattern: \podcast-tui-v{VER}-windows-{arch}.zip\ ✅