### PR TITLE
feat(keybindings): standardize context-dependent key semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Standardize Context-Dependent Key Semantics — February 2026**
 - **`d` now consistently means "delete"** across all buffers; pressing `d` in the sync buffer no longer triggers a dry-run preview — it shows an informational message instead
-- **`D` (Shift+D) triggers dry-run preview** in the sync buffer (previously `d`); `D` already opened episode downloads in episode contexts, making this a clean contextual override with no global conflicts
+- **`D` (Shift-D) triggers dry-run preview** in the sync buffer (previously `d`); `D` already opened episode downloads in episode contexts, making this a clean contextual override with no global conflicts
 - Help text updated: `d → D (Shift-D)` in both the Device Sync and Keybinding Reference sections
 - Tests updated: renamed dry-run test to cover `DownloadEpisode` action; added test confirming `DeletePodcast` in sync buffer shows a "nothing to delete" message. Closes [#95](https://github.com/lqdev/podcast-tui/issues/95).
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -4869,6 +4869,11 @@ mod tests {
             !app.minibuffer.is_input_mode(),
             "Minibuffer should NOT enter input mode for 'd' in sync buffer"
         );
+        // Verify show_message was actually called (not a silent no-op)
+        assert!(
+            app.minibuffer.is_visible(),
+            "Minibuffer should be visible (showing 'nothing to delete' message)"
+        );
     }
 
     #[tokio::test]

--- a/src/ui/buffers/help.rs
+++ b/src/ui/buffers/help.rs
@@ -158,7 +158,7 @@ impl HelpBuffer {
             "  p                    Open directory picker (sync buffer only)".to_string(),
             "  r                    Refresh sync view (sync buffer only)".to_string(),
             "  Enter                Activate selected saved target (sync buffer only)".to_string(),
-            "Dry-Run Preview (after pressing d):".to_string(),
+            "Dry-Run Preview (after pressing D):".to_string(),
             "  [/]                  Cycle between tabs: To Copy, To Delete, Skipped, Errors"
                 .to_string(),
             "  ↑↓                   Scroll file list".to_string(),


### PR DESCRIPTION
## Summary

Closes #95 — Standardizes context-dependent key semantics so that `d` consistently means "delete/remove" across all buffers.

The sync buffer previously intercepted `d` to trigger a dry-run preview, which conflicted with `d` meaning "delete" everywhere else. This PR remaps that action to `D` (Shift+D), which is already the "Download episode" key in episode contexts — a natural fit since there's nothing to download in the sync buffer.

## Changes

- `src/ui/app.rs`: Removed dry-run intercept from `DeletePodcast` handler (sync context); added dry-run intercept to `DownloadEpisode` handler (sync context)
- `src/ui/buffers/help.rs`: Updated Device Sync section and Keybinding Reference: `d` → `D (Shift-D)` for dry-run
- `CHANGELOG.md`: Added entry under `[Unreleased] > Changed`

## Key mapping summary

| Key | Before | After |
|-----|--------|-------|
| `d` in sync buffer | Triggered dry-run preview | Shows "Nothing to delete" message |
| `D` in sync buffer | No special handling | Triggers dry-run preview |
| `d` elsewhere | Delete podcast/playlist | Unchanged |
| `D` elsewhere | Download episode | Unchanged |

## Tests

- Renamed `test_delete_podcast_in_sync_buffer_opens_dry_run_prompt` → `test_download_episode_in_sync_buffer_opens_dry_run_prompt`
- Added `test_delete_podcast_in_sync_buffer_shows_nothing_to_delete`
- All 263 unit tests pass

## Quality

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (263/263 unit tests pass; 1 pre-existing integration test failure in `test_opml_local_file` unrelated to this change)