### PR TITLE
fix(themes): replace hardcoded Color violations with theme methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+**Fix Hardcoded Color Violations — February 2026**
+- **Active buffer indicator** in the buffer list (`buffer_list.rs`) now uses `theme.active_indicator_style()` instead of hardcoded `Color::Yellow`
+- **Error state** in the podcast list (`podcast_list.rs`) — both the border and text — now use `theme.error_style()` instead of hardcoded `Color::Red`
+- **New `active_indicator` color field** added to `ColorScheme`; all 4 bundled themes (dark, light, high-contrast, solarized) provide an appropriate yellow/gold value
+- **New `active_indicator_style()` method** on `Theme` for highlighting active/current items in lists
+- All `Color::` literals are now confined to `src/ui/themes.rs` — no hardcoded colors remain in buffer rendering code. Closes [#101](https://github.com/lqdev/podcast-tui/issues/101).
+
 **Standardize Context-Dependent Key Semantics — February 2026**
 - **`d` now consistently means "delete"** across all buffers; pressing `d` in the sync buffer no longer triggers a dry-run preview — it shows an informational message instead
 - **`D` (Shift-D) triggers dry-run preview** in the sync buffer (previously `d`); `D` already opened episode downloads in episode contexts, making this a clean contextual override with no global conflicts

--- a/src/ui/buffers/buffer_list.rs
+++ b/src/ui/buffers/buffer_list.rs
@@ -5,7 +5,7 @@
 
 use ratatui::{
     layout::Rect,
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame,
 };
@@ -182,7 +182,7 @@ impl UIComponent for BufferListBuffer {
                 };
 
                 let style = if *is_current {
-                    Style::default().fg(Color::Yellow)
+                    self.theme.active_indicator_style()
                 } else {
                     Style::default()
                 };

--- a/src/ui/buffers/podcast_list.rs
+++ b/src/ui/buffers/podcast_list.rs
@@ -5,7 +5,6 @@
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
     Frame,
@@ -353,12 +352,12 @@ impl UIComponent for PodcastListBuffer {
                 let error_block = Block::default()
                     .title("Podcasts - Error")
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::Red))
+                    .border_style(self.theme.error_style())
                     .title_style(self.theme.title_style());
 
                 let error_text = Paragraph::new(error.as_str())
                     .block(error_block)
-                    .style(Style::default().fg(Color::Red))
+                    .style(self.theme.error_style())
                     .wrap(Wrap { trim: true });
 
                 frame.render_widget(error_text, chunks[0]);

--- a/src/ui/key_parser.rs
+++ b/src/ui/key_parser.rs
@@ -87,12 +87,7 @@ pub fn parse_key_notation(notation: &str) -> Result<KeyChord, KeyParseError> {
                 // A single uppercase ASCII letter that isn't a known modifier (C/S/A/M)
                 // is almost certainly a config typo (e.g., "X-n"). Return a specific error
                 // so users get actionable feedback rather than a confusing UnknownKey.
-                if part.len() == 1
-                    && part
-                        .chars()
-                        .next()
-                        .is_some_and(|c| c.is_ascii_uppercase())
-                {
+                if part.len() == 1 && part.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
                     return Err(KeyParseError::InvalidModifier(part.to_string()));
                 }
                 // Multi-char or non-uppercase token — treat everything from here as the key.

--- a/src/ui/themes.rs
+++ b/src/ui/themes.rs
@@ -49,6 +49,9 @@ pub struct ColorScheme {
     pub downloaded: Color,
     pub downloading: Color,
     pub queued: Color,
+
+    // Indicator colors
+    pub active_indicator: Color,
 }
 
 /// Theme manager that provides styling for different UI components
@@ -91,6 +94,8 @@ impl Theme {
             downloaded: Color::Rgb(33, 150, 243),
             downloading: Color::Rgb(156, 39, 176),
             queued: Color::Rgb(158, 158, 158),
+
+            active_indicator: Color::Rgb(255, 193, 7),
         };
 
         Self::new("Default Dark".to_string(), colors)
@@ -123,6 +128,8 @@ impl Theme {
             downloaded: Color::Rgb(13, 110, 253),
             downloading: Color::Rgb(111, 66, 193),
             queued: Color::Rgb(108, 117, 125),
+
+            active_indicator: Color::Rgb(255, 193, 7),
         };
 
         Self::new("Light".to_string(), colors)
@@ -155,6 +162,8 @@ impl Theme {
             downloaded: Color::Cyan,
             downloading: Color::Magenta,
             queued: Color::White,
+
+            active_indicator: Color::Yellow,
         };
 
         Self::new("High Contrast".to_string(), colors)
@@ -187,6 +196,8 @@ impl Theme {
             downloaded: Color::Rgb(38, 139, 210),  // blue
             downloading: Color::Rgb(211, 54, 130), // magenta
             queued: Color::Rgb(101, 123, 131),     // base00
+
+            active_indicator: Color::Rgb(181, 137, 0), // yellow
         };
 
         Self::new("Solarized".to_string(), colors)
@@ -328,6 +339,11 @@ impl Theme {
         Style::default()
             .fg(self.colors.text)
             .bg(self.colors.surface)
+    }
+
+    /// Style for active buffer/item indicators
+    pub fn active_indicator_style(&self) -> Style {
+        Style::default().fg(self.colors.active_indicator)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #101 — Replace all hardcoded `Color::` literals outside `themes.rs` with semantic theme methods. Three violations existed; all are fixed.

## Changes

- `src/ui/themes.rs`: Add `active_indicator: Color` field to `ColorScheme`; populate it in all 4 bundled themes (dark, light, high-contrast, solarized) with appropriate yellow/gold values; add `active_indicator_style()` method on `Theme`
- `src/ui/buffers/buffer_list.rs`: Replace `Style::default().fg(Color::Yellow)` with `theme.active_indicator_style()`; remove now-unused `Color` import
- `src/ui/buffers/podcast_list.rs`: Replace both `Style::default().fg(Color::Red)` (error border + error text) with `theme.error_style()`; remove now-unused `Color` and `Style` imports
- `CHANGELOG.md`: Add entry under `[Unreleased] → Changed`
- `src/ui/key_parser.rs`: Apply pre-existing `rustfmt` reflow (detected by `cargo fmt --check`; no logic change)

## Manual Testing

1. `cargo run`
2. Open the buffer list (`C-x b` or equivalent) — active buffer should appear highlighted in yellow/gold (unchanged from before)
3. Run `:theme light` — active buffer indicator should still be visible (yellow on light background)
4. Run `:theme high-contrast` — active buffer indicator should be terminal yellow
5. Run `:theme solarized` — active buffer indicator should be solarized yellow/gold
6. To verify error state: attempt to add a broken podcast feed URL — the Podcasts buffer should display an error with red text/border (using theme colors, not hardcoded)

## Tests

- 308 unit tests pass (`cargo test --lib`)
- `test_opml_local_file` is a pre-existing failure (missing local file) — unrelated to this change

## Quality

- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test --lib` ✅ (308 passed)
- Verification: `grep -r "Color::" src/ui/buffers/` → zero matches ✅
