### PR TITLE
feat(audio): add PlaybackBackend trait and audio module scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Audio module scaffold (Phase 1)** — new `src/audio/mod.rs` with `PlaybackBackend` trait, `AudioError`, `AudioCommand` enum, and `PlaybackStatus` struct; foundational audio infrastructure for future playback integration. Closes [#133](https://github.com/lqdev/podcast-tui/issues/133), part of [#132](https://github.com/lqdev/podcast-tui/issues/132).
+
 **TOML Theme File Format and Parser — February 2026**
 - **User-defined themes via `.toml` files** — new `src/ui/theme_loader` module parses TOML theme files into the existing `ColorScheme`/`Theme` structs; groundwork for loading themes from the filesystem in [#103](https://github.com/lqdev/podcast-tui/issues/103)
 - **`load_theme_file(path: &Path) -> Result<Theme, ThemeError>`** — public API that reads a TOML file, resolves the base theme via `extends`, applies color overrides, and returns a `Theme` ready for use

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,0 +1,151 @@
+//! Audio playback module — trait abstraction, backends, and coordinator.
+//!
+//! Architecture:
+//! - [`PlaybackBackend`]: synchronous interface, implementations run on a dedicated `std::thread`
+//! - [`AudioError`]: domain error type (thiserror)
+//! - [`AudioCommand`]: commands from the UI → AudioManager
+//! - [`PlaybackStatus`]: broadcast state from AudioManager → UI
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::storage::{EpisodeId, PodcastId};
+
+/// Errors that can occur during audio playback.
+#[derive(Debug, thiserror::Error)]
+pub enum AudioError {
+    #[error("Audio device not found")]
+    DeviceNotFound,
+    #[error("Failed to decode audio file: {0}")]
+    DecodingFailed(String),
+    #[error("Seek failed: {0}")]
+    SeekFailed(String),
+    #[error("External player not found: {0}")]
+    ExternalPlayerNotFound(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Current playback state.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlaybackState {
+    Playing,
+    Paused,
+    Stopped,
+}
+
+/// Commands sent from the UI to the `AudioManager`.
+#[derive(Debug, Clone)]
+pub enum AudioCommand {
+    Play {
+        path: std::path::PathBuf,
+        episode_id: EpisodeId,
+        podcast_id: PodcastId,
+    },
+    Pause,
+    Resume,
+    TogglePlayPause,
+    Stop,
+    SeekForward(Duration),
+    SeekBackward(Duration),
+    SetVolume(f32),
+    VolumeUp,
+    VolumeDown,
+}
+
+/// Playback status broadcast from `AudioManager` to the UI.
+#[derive(Debug, Clone)]
+pub struct PlaybackStatus {
+    pub state: PlaybackState,
+    pub episode_id: Option<EpisodeId>,
+    pub podcast_id: Option<PodcastId>,
+    pub position: Option<Duration>,
+    pub duration: Option<Duration>,
+    pub volume: f32,
+}
+
+impl Default for PlaybackStatus {
+    fn default() -> Self {
+        Self {
+            state: PlaybackState::Stopped,
+            episode_id: None,
+            podcast_id: None,
+            position: None,
+            duration: None,
+            volume: crate::constants::audio::DEFAULT_VOLUME,
+        }
+    }
+}
+
+/// Trait abstracting over different audio playback backends.
+///
+/// Implementations are expected to run synchronously on a dedicated `std::thread`,
+/// not on the tokio async executor, to avoid cpal/tokio deadlock risk.
+pub trait PlaybackBackend: Send {
+    fn play(&mut self, path: &Path) -> Result<(), AudioError>;
+    fn pause(&mut self);
+    fn resume(&mut self);
+    fn stop(&mut self);
+    fn seek(&mut self, position: Duration) -> Result<(), AudioError>;
+    fn set_volume(&mut self, volume: f32);
+    fn position(&self) -> Option<Duration>;
+    fn duration(&self) -> Option<Duration>;
+    fn is_playing(&self) -> bool;
+    fn is_paused(&self) -> bool;
+    fn is_stopped(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_playback_status_default_is_stopped_at_default_volume() {
+        // Arrange / Act
+        let status = PlaybackStatus::default();
+
+        // Assert
+        assert_eq!(status.state, PlaybackState::Stopped);
+        assert_eq!(status.volume, crate::constants::audio::DEFAULT_VOLUME);
+        assert!(status.episode_id.is_none());
+        assert!(status.podcast_id.is_none());
+        assert!(status.position.is_none());
+        assert!(status.duration.is_none());
+    }
+
+    #[test]
+    fn test_audio_error_display_device_not_found() {
+        // Arrange / Act
+        let err = AudioError::DeviceNotFound;
+
+        // Assert
+        assert_eq!(err.to_string(), "Audio device not found");
+    }
+
+    #[test]
+    fn test_audio_error_display_decoding_failed() {
+        // Arrange / Act
+        let err = AudioError::DecodingFailed("bad mp3".to_string());
+
+        // Assert
+        assert_eq!(err.to_string(), "Failed to decode audio file: bad mp3");
+    }
+
+    #[test]
+    fn test_audio_error_display_seek_failed() {
+        // Arrange / Act
+        let err = AudioError::SeekFailed("sink error".to_string());
+
+        // Assert
+        assert_eq!(err.to_string(), "Seek failed: sink error");
+    }
+
+    #[test]
+    fn test_audio_error_display_external_player_not_found() {
+        // Arrange / Act
+        let err = AudioError::ExternalPlayerNotFound("vlc".to_string());
+
+        // Assert
+        assert_eq!(err.to_string(), "External player not found: vlc");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod audio;
 pub mod config;
 pub mod constants;
 pub mod download;


### PR DESCRIPTION
## Summary

Closes #133 — creates the foundational audio abstraction layer (`src/audio/mod.rs`) that both `RodioBackend` (#134) and `ExternalPlayerBackend` (#135) will implement.

## Changes

- `src/audio/mod.rs` — **new file** with all core audio types:
  - `PlaybackBackend` trait: synchronous interface (`Send`), runs on a dedicated `std::thread`
  - `AudioError`: thiserror-backed error enum (DeviceNotFound, DecodingFailed, SeekFailed, ExternalPlayerNotFound, Io)
  - `AudioCommand` enum: Play, Pause, Resume, TogglePlayPause, Stop, SeekForward/Backward, SetVolume, VolumeUp, VolumeDown
  - `PlaybackStatus` struct: state, episode_id, podcast_id, position, duration, volume — with `Default` impl (Stopped, `DEFAULT_VOLUME`)
- `src/lib.rs` — added `pub mod audio;` to register the new module
- `CHANGELOG.md` — added entry under `[Unreleased] / Added`

## Manual Testing

N/A — this is pure infrastructure (trait definition + types). No UI-observable behavior yet.
The trait will be implemented in #134 (RodioBackend) and #135 (ExternalPlayerBackend),
and wired into the app in #136 (AudioManager) and #138 (Playback UIActions).

## Tests

5 new unit tests in `src/audio/mod.rs`:
- `test_playback_status_default_is_stopped_at_default_volume`
- `test_audio_error_display_device_not_found`
- `test_audio_error_display_decoding_failed`
- `test_audio_error_display_seek_failed`
- `test_audio_error_display_external_player_not_found`

Total: 394 tests (was 389).

## Quality

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (394 passed; pre-existing OPML integration test failure unrelated to this PR)