### PR TITLE
feat(ui): Playback UIActions and AppEvents

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1306,6 +1306,46 @@ impl UIApp {
                 self.trigger_async_add_podcast(feed_url);
                 Ok(true)
             }
+            // Audio playback — pass to buffer to resolve the selected episode, then dispatch
+            // to AudioManager (wired in #141).
+            UIAction::PlayEpisode { .. } => {
+                if let Some(current_buffer) = self.buffer_manager.current_buffer_mut() {
+                    let result = current_buffer.handle_action(action);
+                    match result {
+                        UIAction::PlayEpisode { .. } => {
+                            // Stub: AudioManager dispatch wired in #141
+                        }
+                        UIAction::ShowError(msg) => self.show_error(msg),
+                        _ => {}
+                    }
+                }
+                Ok(true)
+            }
+            // Simple playback controls forwarded to AudioManager in #141
+            UIAction::TogglePlayPause => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
+            UIAction::StopPlayback => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
+            UIAction::SeekForward => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
+            UIAction::SeekBackward => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
+            UIAction::VolumeUp => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
+            UIAction::VolumeDown => {
+                // Stub: AudioManager dispatch wired in #141
+                Ok(true)
+            }
             // Buffer-specific actions
             action => {
                 if let Some(current_buffer) = self.buffer_manager.current_buffer_mut() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -303,6 +303,26 @@ pub enum UIAction {
     SubscribeFromDiscovery {
         feed_url: String,
     },
+
+    // Audio playback actions
+    /// Play a downloaded episode through the audio backend
+    PlayEpisode {
+        podcast_id: crate::storage::PodcastId,
+        episode_id: crate::storage::EpisodeId,
+        path: std::path::PathBuf,
+    },
+    /// Toggle play/pause for the current track
+    TogglePlayPause,
+    /// Stop playback and clear the current track
+    StopPlayback,
+    /// Seek forward by `constants::audio::SEEK_STEP_SECS`
+    SeekForward,
+    /// Seek backward by `constants::audio::SEEK_STEP_SECS`
+    SeekBackward,
+    /// Increase volume by `constants::audio::VOLUME_STEP`
+    VolumeUp,
+    /// Decrease volume by `constants::audio::VOLUME_STEP`
+    VolumeDown,
 }
 
 impl UIAction {
@@ -371,6 +391,14 @@ impl UIAction {
             UIAction::SyncToDevice => "Sync to device",
             UIAction::PreviousTab => "Previous tab",
             UIAction::NextTab => "Next tab",
+            // Audio playback
+            UIAction::PlayEpisode { .. } => "Play selected episode",
+            UIAction::TogglePlayPause => "Toggle play / pause",
+            UIAction::StopPlayback => "Stop playback",
+            UIAction::SeekForward => "Seek forward",
+            UIAction::SeekBackward => "Seek backward",
+            UIAction::VolumeUp => "Volume up",
+            UIAction::VolumeDown => "Volume down",
             // Internal / trigger actions — not shown in help
             _ => "",
         }


### PR DESCRIPTION
## Summary

Closes #138 — adds the full vocabulary of playback `UIAction` and `AppEvent` variants that the keybinding system, NowPlaying buffer, and AudioManager wiring will consume in subsequent issues.

## Changes

- `src/ui/mod.rs`: Add 7 playback `UIAction` variants: `PlayEpisode { podcast_id, episode_id, path }`, `TogglePlayPause`, `StopPlayback`, `SeekForward`, `SeekBackward`, `VolumeUp`, `VolumeDown`. Added `description()` entries for each so they appear in the keybinding help system.
- `src/ui/buffers/episode_list.rs`: `handle_action` arm for `PlayEpisode { .. }` — resolves the selected episode and returns a fully-populated `PlayEpisode { podcast_id, episode_id, path }` when `episode.local_path.is_some()`, or `ShowError` when the episode is not yet downloaded.
- `src/ui/app.rs`: Stub match arms for all 7 new `UIAction` variants. Actual AudioManager dispatch wired in #141.
- `CHANGELOG.md`: Entry under `[Unreleased]`.

**Note:** `AppEvent` audio variants (`PlaybackStarted`, `PlaybackStopped`, `TrackEnded`, `PlaybackError`) were already added in PR #163 / issue #136 and are not duplicated here.

## Manual Testing

N/A — the new `UIAction` variants are not yet bound to keys (that's #139) and not yet dispatched to AudioManager (that's #141). The observable behavior change is only the guard logic: selecting an undownloaded episode and triggering `PlayEpisode` returns an error. This is fully covered by the 2 unit tests below.

## Tests

- `test_play_episode_action_requires_local_path` — `PlayEpisode` on an episode with `local_path = None` returns `ShowError`
- `test_play_episode_action_contains_correct_path` — `PlayEpisode` on a downloaded episode returns `PlayEpisode` with correct `podcast_id`, `episode_id`, and `path`

## Quality

- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (548 passed; `test_opml_local_file` is a pre-existing failure unrelated to these changes)