### PR TITLE
feat(audio): wire AudioManager into App event loop

### DIFF
--- a/src/audio/manager.rs
+++ b/src/audio/manager.rs
@@ -79,6 +79,13 @@ impl AudioManager {
     pub fn subscribe(&self) -> watch::Receiver<PlaybackStatus> {
         self.status_rx.clone()
     }
+
+    /// Return a cloned `UnboundedSender` for sending commands to the audio thread.
+    ///
+    /// Used by `UIApp` to dispatch playback actions without holding the full manager.
+    pub fn command_tx(&self) -> mpsc::UnboundedSender<AudioCommand> {
+        self.command_tx.clone()
+    }
 }
 
 // ---------- Backend selection -----------------------------------------------

--- a/src/ui/buffers/now_playing.rs
+++ b/src/ui/buffers/now_playing.rs
@@ -75,6 +75,16 @@ impl NowPlayingBuffer {
         self.podcast_name = podcast_name;
     }
 
+    /// Returns the episode title currently shown in this buffer, if any.
+    pub fn episode_title(&self) -> Option<&str> {
+        self.episode_title.as_deref()
+    }
+
+    /// Returns the podcast name currently shown in this buffer, if any.
+    pub fn podcast_name(&self) -> Option<&str> {
+        self.podcast_name.as_deref()
+    }
+
     /// Set the theme for this buffer.
     pub fn set_theme(&mut self, theme: Theme) {
         self.theme = theme;


### PR DESCRIPTION
## Summary

Closes #141 — wires the existing `AudioManager` infrastructure into the `App` event loop so playback works end-to-end. This is the final integration step in the audio playback epic (#137).

## Changes

- `src/audio/manager.rs`: added `pub fn command_tx()` to expose a cloneable `UnboundedSender<AudioCommand>`
- `src/app.rs`: `App::run()` creates `AudioManager`, extracts sender + status receiver, sets both on `UIApp`; graceful `eprintln!` fallback keeps app functional when audio init fails
- `src/ui/app.rs`:
  - New `audio_command_tx: Option<mpsc::UnboundedSender<AudioCommand>>` field + `set_audio_command_tx()` setter (constructors unchanged — no test breakage)
  - `UIApp::run()` accepts `playback_status_rx: Option<watch::Receiver<PlaybackStatus>>`; wires to NowPlaying buffer; adds `select!` branch to re-render on status ticks
  - Replaced 7 playback `UIAction` stubs with real `AudioCommand` dispatch
  - Replaced 4 `AppEvent` playback stubs with real business logic (position persistence, played-status, buffer refresh)
- `src/ui/buffers/now_playing.rs`: added `episode_title()` and `podcast_name()` public getters
- 8 new unit tests

## Manual Testing

1. `cargo run`
2. Subscribe to a podcast and download an episode
3. Select the episode in the episode list and press `Enter` / `p` to play → status bar and NowPlaying buffer (`F9`) should show the episode name and ▶ icon
4. Press `S-P` (Shift+P) → playback pauses (⏸ icon); press again → resumes (▶ icon)
5. Press `+` / `-` → volume changes (reflected in NowPlaying buffer progress area)
6. Press `C-Right` / `C-Left` → seek forward/backward 10 seconds
7. Let episode play to end → status changes to Played in episode list; minibuffer shows "Finished playing episode"
8. On a system without audio support: app starts normally with no crash; playback actions show a graceful error in the minibuffer

## Tests

- 8 unit tests covering: TogglePlayPause command dispatch, minibuffer input-mode guard, StopPlayback dispatch, VolumeUp dispatch, TrackEnded persistence (with and without duration), PlaybackStarted NowPlaying info, PlaybackError display

## Quality

- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test --lib` ✅ (573 passed, 0 failed)