### PR TITLE
fix(theme): propagate :theme command to all buffers and minibuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`:theme` command now visually updates all open buffers and the minibuffer** — February 2026
+  - Previously `:theme <name>` only updated the status bar and `self.theme`; all open buffers (podcast list, episode list, downloads, etc.) and the minibuffer kept the old theme's colours until the user restarted the app.
+  - Fixed by calling `BufferManager::set_theme_all()` and `Minibuffer::set_theme()` from `set_theme_direct()`.
+  - Six buffers (podcast list, episode list, episode detail, What's New, help, now playing) had inherent `set_theme()` methods but did not override the `Buffer` trait's `set_theme()`, so theme changes through `dyn Buffer` hit the no-op default. Added trait overrides for all six.
+  - Closes [#167](https://github.com/lqdev/podcast-tui/issues/167).
+
 - **`PlayEpisode` now has a default keybinding: `S-Enter` (Shift+Enter)** — audio playback was completely unreachable with default config — February 2026
   - `PlayEpisode` had no default keybinding (`play_episode: vec![]` in both `default_preset()` and `Config::default()`), making it literally impossible to start playing an episode without editing `config.json`. `Enter` opens the episode detail buffer; `p` adds to playlist; `S-P` only toggles between playing/paused (no effect when stopped). No `:play` minibuffer command exists.
   - Fixed by binding `S-Enter` (Shift+Enter) to `PlayEpisode` in `setup_default_bindings()` and setting `play_episode: ["S-Enter"]` in `default_preset()`. `Enter` (plain) is unaffected and still opens episode detail.

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2770,6 +2770,8 @@ impl UIApp {
         match self.theme_registry.get(theme_name).cloned() {
             Some(new_theme) => {
                 self.theme = new_theme.clone();
+                self.buffer_manager.set_theme_all(&new_theme);
+                self.minibuffer.set_theme(new_theme.clone());
                 self.status_bar.set_theme(new_theme);
                 self.show_message(format!("Theme changed to: {}", theme_name));
                 Ok(true)
@@ -5505,6 +5507,8 @@ mod tests {
         let result = app.set_theme_direct("light");
         assert!(result.is_ok());
         assert!(result.unwrap());
+        // Verify theme propagated to app
+        assert_eq!(app.theme.name, "Light");
 
         let result = app.set_theme_direct("invalid-theme");
         assert!(result.is_ok());

--- a/src/ui/buffers/buffer_list.rs
+++ b/src/ui/buffers/buffer_list.rs
@@ -120,6 +120,10 @@ impl Buffer for BufferListBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/discovery.rs
+++ b/src/ui/buffers/discovery.rs
@@ -357,6 +357,10 @@ impl Buffer for DiscoveryBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn help_text(&self) -> Vec<String> {
         vec![
             "DISCOVERY BUFFER".to_string(),

--- a/src/ui/buffers/downloads.rs
+++ b/src/ui/buffers/downloads.rs
@@ -263,6 +263,10 @@ impl Buffer for DownloadsBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/episode_detail.rs
+++ b/src/ui/buffers/episode_detail.rs
@@ -244,6 +244,10 @@ impl Buffer for EpisodeDetailBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/episode_list.rs
+++ b/src/ui/buffers/episode_list.rs
@@ -349,6 +349,10 @@ impl Buffer for EpisodeListBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/help.rs
+++ b/src/ui/buffers/help.rs
@@ -323,6 +323,10 @@ impl Buffer for HelpBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/now_playing.rs
+++ b/src/ui/buffers/now_playing.rs
@@ -311,6 +311,10 @@ impl Buffer for NowPlayingBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         // Persistent buffer — not closeable with C-k.
         false

--- a/src/ui/buffers/playlist_detail.rs
+++ b/src/ui/buffers/playlist_detail.rs
@@ -148,6 +148,10 @@ impl Buffer for PlaylistDetailBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn help_text(&self) -> Vec<String> {
         vec![
             "Playlist Detail Commands:".to_string(),

--- a/src/ui/buffers/playlist_list.rs
+++ b/src/ui/buffers/playlist_list.rs
@@ -112,6 +112,10 @@ impl Buffer for PlaylistListBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn help_text(&self) -> Vec<String> {
         vec![
             "Playlist Commands:".to_string(),

--- a/src/ui/buffers/playlist_picker.rs
+++ b/src/ui/buffers/playlist_picker.rs
@@ -86,6 +86,10 @@ impl Buffer for PlaylistPickerBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn help_text(&self) -> Vec<String> {
         vec![
             "Playlist Picker Commands:".to_string(),

--- a/src/ui/buffers/podcast_list.rs
+++ b/src/ui/buffers/podcast_list.rs
@@ -207,6 +207,10 @@ impl Buffer for PodcastListBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         false // Main podcast list shouldn't be closeable
     }

--- a/src/ui/buffers/sync.rs
+++ b/src/ui/buffers/sync.rs
@@ -825,6 +825,10 @@ impl Buffer for SyncBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         true
     }

--- a/src/ui/buffers/whats_new.rs
+++ b/src/ui/buffers/whats_new.rs
@@ -244,6 +244,10 @@ impl Buffer for WhatsNewBuffer {
         self
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
+
     fn can_close(&self) -> bool {
         false // Core buffer, cannot be closed
     }


### PR DESCRIPTION
## Summary

Closes #167 — `:theme <name>` now visually updates all open buffers and the minibuffer, not just the status bar.

## Changes

- `src/ui/buffers/mod.rs`: Added `fn set_theme(&mut self, _theme: Theme) {}` default method to `Buffer` trait; added `current_theme: Theme` field and `set_theme_all()` method to `BufferManager`; `add_buffer()` now applies the stored theme to newly added buffers; added `test_set_theme_all_propagates_to_all_buffers` test with a mock `ThemeTracker` buffer
- `src/ui/app.rs`: `set_theme_direct()` now calls `buffer_manager.set_theme_all()` and `minibuffer.set_theme()` before `status_bar.set_theme()`; enhanced `test_theme_setting` to verify `app.theme.name` after theme change
- `src/ui/buffers/{podcast_list,episode_list,episode_detail,whats_new,help,now_playing}.rs`: Added `fn set_theme()` override in `impl Buffer for` — these six buffers had inherent `pub fn set_theme()` methods but did not override the trait, so `dyn Buffer` dispatch hit the no-op default
- `src/ui/buffers/{downloads,discovery,sync,playlist_detail,playlist_picker,playlist_list,buffer_list}.rs`: Added `fn set_theme()` override in `impl Buffer for` — these seven buffers had no `set_theme` at all
- `CHANGELOG.md`: Added entry under `[Unreleased] > Fixed`

## Root Cause

`set_theme_direct()` only updated `self.theme` and `self.status_bar`. The `Buffer` trait had no `set_theme` method, so there was no way to propagate theme changes to buffers through `dyn Buffer`. Six buffers had inherent `pub fn set_theme()` methods, but inherent methods are invisible when calling through trait objects — the no-op default was invoked instead.

## Manual Testing

1. `cargo run`
2. Type `:theme light` and press Enter → all visible buffer content (podcast list, episode list, etc.) should immediately render with the light colour scheme; the status bar and minibuffer should also update
3. Type `:theme dark` and press Enter → everything reverts to dark colours
4. Open a new buffer (e.g., press `?` for help) → the new buffer should use the current theme, not the default dark theme
5. Type `:theme nonexistent` → should show "Unknown theme: nonexistent" error in the minibuffer

## Tests

- 1 new unit test (`test_set_theme_all_propagates_to_all_buffers`) — verifies `set_theme_all` calls each buffer's `set_theme` and stores the theme for future buffers
- 1 enhanced test (`test_theme_setting`) — verifies `app.theme.name` updates after `set_theme_direct("light")`
- 583 total unit tests passing

## Quality

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test --lib` ✅ (583 passed)