### PR TITLE
test(audio): replace fixed sleeps with event-driven polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Audio integration tests now use event-driven polling instead of fixed sleeps** — February 2026
+  - Replaced all `tokio::time::sleep(STATUS_BROADCAST_DELAY)` calls in `tests/test_audio.rs` with a new `wait_for_status()` helper that polls `watch::Receiver::changed()` with a predicate and generous timeout. Tests no longer depend on the 250 ms run_loop interval.
+  - `test_audio_manager_clean_shutdown_on_drop` now verifies thread exit by draining the `app_rx` channel until `recv()` returns `None`, proving the audio thread dropped its sender.
+  - Closes [#177](https://github.com/lqdev/podcast-tui/issues/177).
+
 ### Fixed
 
 - **`:theme` command now visually updates all open buffers and the minibuffer** — February 2026


### PR DESCRIPTION
## Summary

Closes #177 — Replaces fragile fixed-sleep timing in audio integration tests with event-driven polling using `watch::Receiver::changed()`, and strengthens the shutdown assertion to verify thread exit.

## Changes

- `tests/test_audio.rs`:
  - **New `wait_for_status()` helper**: Polls `watch::Receiver::changed()` with a predicate + timeout. Replaces all `tokio::time::sleep(STATUS_BROADCAST_DELAY)` calls.
  - **Renamed constant**: `STATUS_BROADCAST_DELAY` (400 ms) → `STATUS_CHANGE_TIMEOUT` (3 s generous bound). Tests no longer depend on the 250 ms `run_loop` interval.
  - **Stronger shutdown test**: `test_audio_manager_clean_shutdown_on_drop` now drains `app_rx` until `recv()` returns `None`, proving the audio thread dropped its sender — instead of sleeping and asserting "we reached this point."
  - **Hardware tests converted**: Both `#[ignore]` tests also use `wait_for_status()` instead of fixed sleeps.
- `CHANGELOG.md`: Added entry under `[Unreleased] > Changed`.

## Manual Testing

N/A — internal test infrastructure change with no observable UI or runtime behavior change. All behavior is verified by the 5 CI-safe integration tests and the existing 583 unit tests.

## Tests

- 5 CI-safe integration tests pass: `cargo test --test test_audio`
- 2 hardware-dependent tests updated (verified structurally; require audio device to run)
- Ran 5x in a loop with zero flakiness
- 583 unit tests pass with no regressions

## Quality

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (excluding pre-existing `test_opml_local_file` failure)