### PR TITLE
perf(startup): remove artificial sleep delays from startup path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -456,13 +456,11 @@ async fn main() -> Result<()> {
             if let Err(e) = update_splash_status(status.message()) {
                 eprintln!("Failed to update splash status: {}", e);
             }
-            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         }
     });
 
     // Load configuration
     update_splash_status(InitStatus::LoadingConfig.message())?;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     let config_path = matches.get_one::<String>("config");
     let config = Config::load_or_default(config_path)?;
@@ -479,7 +477,6 @@ async fn main() -> Result<()> {
 
     // Show final status briefly
     update_splash_status(InitStatus::Complete.message())?;
-    tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
 
     // Clear splash screen and show cursor
     execute!(


### PR DESCRIPTION
## Summary

Closes #186 — removes three hardcoded `tokio::time::sleep()` calls from the startup path that added a combined ~1.1 seconds of artificial waiting time before the UI becomes interactive.

## Changes

- `src/main.rs`: Remove 200ms sleep from `status_monitor` loop (line 459)
- `src/main.rs`: Remove 100ms post-config-load sleep (line 465)
- `src/main.rs`: Remove 800ms "Ready!" splash hold (line 482)

## Manual Testing

1. `cargo run`
2. Observe startup — the splash screen status messages (Loading config, Initializing storage, etc.) still cycle through correctly, just without artificial pauses
3. App enters TUI immediately after initialization completes (no 800ms hold on "Ready!")
4. Before this change: ~1.1s of pure sleep before entering TUI. After: enters immediately.

## Tests

- 589 unit tests pass, 5 integration tests pass
- Pre-existing `test_opml_local_file` failure is unrelated (missing test fixture file on this machine — fails on `main` too)

## Quality

- `cargo fmt --check` ✅
- `cargo build` ✅
- `cargo test` ✅ (all relevant tests pass)