### PR TITLE
feat(ui): add configurable startup buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable startup buffer** — Choose which buffer opens on launch via `ui.startup_buffer` in `~/.config/podcast-tui/config.json`. Valid values: `"help"` (default, preserves existing behavior), `"podcast-list"`, `"downloads"`, `"sync"`, `"playlist-list"`, `"whats-new"`, `"now-playing"`. Unknown values fall back to `"help"` with a console warning. Closes #203.
+
 **Nix Packaging — Binary-Fetch Flake**
 - **Sub-10s install on supported platforms**: New `packages.podcast-tui-bin` derivation consumes prebuilt GitHub Release tarballs via `fetchurl` + `autoPatchelfHook`, eliminating the 5–15 min source compile for `nix run`/`nix profile install`/declarative installs. Source build (`packages.podcast-tui-source`) remains for `nix flake check` and as a graceful fallback on platforms without a published binary. `packages.default` routes per-system. ([ADR-005](docs/adr/ADR-005-binary-fetch-flake.md))
 - **Home Manager + NixOS modules**: `homeManagerModules.default` (and the renamed `homeModules.default` alias) plus `nixosModules.default` expose `programs.podcast-tui.enable = true;` — no more manual `home.packages = [ inputs.podcast-tui.packages.${pkgs.system}.default ];` boilerplate.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -22,6 +22,30 @@ Three presets are available. Set one in `~/.config/podcast-tui/config.json`:
 
 If `preset` is omitted or unrecognised, `default` is used.
 
+## Startup Buffer
+
+Choose which buffer opens when Podcast TUI launches. Add `ui.startup_buffer` to `~/.config/podcast-tui/config.json`:
+
+```json
+{
+  "ui": {
+    "startup_buffer": "whats-new"
+  }
+}
+```
+
+| Value | Buffer |
+|-------|--------|
+| `help` (default) | `*Help: Keybindings*` — auto-generated keybinding reference |
+| `podcast-list` | Subscribed podcasts |
+| `downloads` | Active and recent downloads |
+| `sync` | Device sync history |
+| `playlist-list` | Playlists |
+| `whats-new` | Rolling new episodes across all podcasts |
+| `now-playing` | Audio playback status |
+
+Unknown values fall back to `help` and log a warning to stderr.
+
 ## Auto-Generated Help
 
 Press `F1`, `?`, or run `:help` to open `*Help: Keybindings*`. This buffer reflects whichever preset is active for the current session. If you change `config.json` (including the `preset`), restart Podcast TUI to update the keybindings shown here.

--- a/src/config.rs
+++ b/src/config.rs
@@ -708,11 +708,21 @@ pub struct UiConfig {
     // NOTE: Duration filter config (filter_short_max_minutes, filter_long_min_minutes)
     // deferred until episode duration data is populated from RSS feeds.
     // See Design Decision #13 in docs/SEARCH_AND_FILTER.md.
+    /// Buffer to open on application startup. Valid values:
+    /// `"help"`, `"podcast-list"`, `"downloads"`, `"sync"`,
+    /// `"playlist-list"`, `"whats-new"`, `"now-playing"`.
+    /// Unknown values fall back to `"help"` with a warning.
+    #[serde(default = "default_startup_buffer")]
+    pub startup_buffer: String,
 }
 
 // Default function for serde
 fn default_whats_new_episode_limit() -> usize {
     ui::DEFAULT_WHATS_NEW_LIMIT
+}
+
+fn default_startup_buffer() -> String {
+    "help".to_string()
 }
 
 // NOTE: Duration filter default fns removed — deferred until extract_duration is implemented.
@@ -729,6 +739,7 @@ impl Default for UiConfig {
             compact_mode: false,
             mouse_support: true,
             whats_new_episode_limit: ui::DEFAULT_WHATS_NEW_LIMIT,
+            startup_buffer: default_startup_buffer(),
         }
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -45,6 +45,26 @@ use crate::{
 use directories::ProjectDirs;
 use std::sync::Arc;
 
+/// Resolve the configured startup buffer name to an actual buffer ID.
+///
+/// All buffers except `help` use their kebab-case name as their ID directly,
+/// so we just verify the ID exists. `help` uses a UUID-suffixed ID and must
+/// be looked up by display title.
+///
+/// Returns `None` if `name` is not a recognized buffer.
+fn resolve_startup_buffer_id(buffer_manager: &BufferManager, name: &str) -> Option<String> {
+    match name {
+        "help" => buffer_manager.find_buffer_id_by_name("*Help: Keybindings*"),
+        "podcast-list" | "downloads" | "sync" | "playlist-list" | "whats-new" | "now-playing" => {
+            buffer_manager
+                .get_buffer_ids()
+                .into_iter()
+                .find(|id| id == name)
+        }
+        _ => None,
+    }
+}
+
 /// The main UI application
 pub struct UIApp {
     /// Configuration
@@ -282,9 +302,18 @@ impl UIApp {
         );
         buffer_manager.create_now_playing_buffer();
 
-        // Set initial buffer
-        if let Some(buffer_id) = buffer_manager.get_buffer_ids().first() {
-            let _ = buffer_manager.switch_to_buffer(&buffer_id.clone());
+        // Set initial buffer (configurable via ui.startup_buffer)
+        let target_id = resolve_startup_buffer_id(&buffer_manager, &config.ui.startup_buffer)
+            .or_else(|| {
+                eprintln!(
+                    "[config] Unknown ui.startup_buffer '{}', falling back to 'help'",
+                    config.ui.startup_buffer
+                );
+                resolve_startup_buffer_id(&buffer_manager, "help")
+            })
+            .or_else(|| buffer_manager.get_buffer_ids().first().cloned());
+        if let Some(id) = target_id {
+            let _ = buffer_manager.switch_to_buffer(&id);
         }
 
         // Skip loading data during initialization - it will be loaded asynchronously in the background
@@ -567,9 +596,19 @@ impl UIApp {
             .create_playlist_list_buffer(self.playlist_manager.clone());
         self.buffer_manager.create_now_playing_buffer();
 
-        // Set initial buffer
-        if let Some(buffer_id) = self.buffer_manager.get_buffer_ids().first() {
-            let _ = self.buffer_manager.switch_to_buffer(&buffer_id.clone());
+        // Set initial buffer (configurable via ui.startup_buffer)
+        let target_id =
+            resolve_startup_buffer_id(&self.buffer_manager, &self.config.ui.startup_buffer)
+                .or_else(|| {
+                    eprintln!(
+                        "[config] Unknown ui.startup_buffer '{}', falling back to 'help'",
+                        self.config.ui.startup_buffer
+                    );
+                    resolve_startup_buffer_id(&self.buffer_manager, "help")
+                })
+                .or_else(|| self.buffer_manager.get_buffer_ids().first().cloned());
+        if let Some(id) = target_id {
+            let _ = self.buffer_manager.switch_to_buffer(&id);
         }
 
         // Update status bar
@@ -5463,6 +5502,86 @@ mod tests {
         let app = app.unwrap();
         assert!(!app.should_quit);
         assert_eq!(app.frame_count, 0);
+    }
+
+    /// Helper to construct a UIApp with the given UiConfig for startup-buffer tests.
+    async fn make_app_with_ui_config(ui: UiConfig) -> UIApp {
+        use crate::config::DownloadConfig;
+        use crate::storage::JsonStorage;
+        use tempfile::TempDir;
+
+        let config = Config {
+            ui,
+            ..Default::default()
+        };
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Arc::new(JsonStorage::with_data_dir(temp_dir.path().to_path_buf()));
+        let download_manager = Arc::new(
+            DownloadManager::new(
+                storage.clone(),
+                temp_dir.path().to_path_buf(),
+                DownloadConfig::default(),
+            )
+            .unwrap(),
+        );
+        let subscription_manager = Arc::new(SubscriptionManager::with_download_manager(
+            storage.clone(),
+            download_manager.clone(),
+        ));
+        let (app_event_tx, _rx) = mpsc::unbounded_channel();
+        let mut app = UIApp::new(
+            config,
+            subscription_manager,
+            download_manager,
+            storage,
+            app_event_tx,
+        )
+        .unwrap();
+        // initialize() is what actually creates buffers and applies the
+        // configured startup_buffer selection.
+        app.initialize().await.unwrap();
+        app
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_default_is_help() {
+        // Default UiConfig must preserve current behavior: land on Help.
+        let app = make_app_with_ui_config(UiConfig::default()).await;
+        let name = app.buffer_manager.current_buffer_name();
+        assert_eq!(name.as_deref(), Some("*Help: Keybindings*"));
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_whats_new() {
+        let app = make_app_with_ui_config(UiConfig {
+            startup_buffer: "whats-new".to_string(),
+            ..UiConfig::default()
+        })
+        .await;
+        let name = app.buffer_manager.current_buffer_name();
+        assert_eq!(name.as_deref(), Some("What's New"));
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_downloads() {
+        let app = make_app_with_ui_config(UiConfig {
+            startup_buffer: "downloads".to_string(),
+            ..UiConfig::default()
+        })
+        .await;
+        let name = app.buffer_manager.current_buffer_name();
+        assert_eq!(name.as_deref(), Some("Downloads"));
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_invalid_falls_back_to_help() {
+        let app = make_app_with_ui_config(UiConfig {
+            startup_buffer: "nonexistent-buffer".to_string(),
+            ..UiConfig::default()
+        })
+        .await;
+        let name = app.buffer_manager.current_buffer_name();
+        assert_eq!(name.as_deref(), Some("*Help: Keybindings*"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #203 — adds a `ui.startup_buffer` config field that lets users choose which buffer opens on launch. Default value is `"help"`, preserving today's behavior. Recognized values: `help`, `podcast-list`, `downloads`, `sync`, `playlist-list`, `whats-new`, `now-playing`. Unknown values fall back to `help` and log a warning to stderr.

## Changes

- `src/config.rs`: added `pub startup_buffer: String` to `UiConfig` with `#[serde(default = "default_startup_buffer")]` and matching default in `impl Default`. Field is omittable in existing `config.json` files (backward-compatible).
- `src/ui/app.rs`:
  - New `resolve_startup_buffer_id` helper. Six of seven buffers use their kebab-case name as their `BufferId` directly (e.g. `whats-new`, `downloads`); only the help buffer uses a UUID-suffixed id and is looked up via `find_buffer_id_by_name("*Help: Keybindings*")`.
  - Replaced the unconditional `get_buffer_ids().first()` selection in both `UIApp::new_with_progress` (line ~305) and `UIApp::initialize` (line ~599) with the resolver, plus a fallback chain (configured value → `"help"` → first available).
  - 4 new unit tests in the existing `tests` module covering: default → Help, `whats-new` → What's New, `downloads` → Downloads, invalid value → falls back to Help.
- `CHANGELOG.md`: entry under `[Unreleased] / Added`.
- `docs/KEYBINDINGS.md`: new `## Startup Buffer` section between Presets and Auto-Generated Help, with the full value table.

## Manual Testing

1. `cargo run` with no `startup_buffer` in config → app opens to `*Help: Keybindings*` (unchanged from today).
2. Edit `~/.config/podcast-tui/config.json`, set `"ui": { "startup_buffer": "whats-new" }`, restart → app opens to **What''s New**.
3. Set `"startup_buffer": "downloads"`, restart → app opens to **Downloads**.
4. Set `"startup_buffer": "garbage-value"`, restart → stderr prints `[config] Unknown ui.startup_buffer ''garbage-value'', falling back to ''help''` and the app opens to Help.
5. Delete the config file → app starts cleanly with all defaults; lands on Help.

## Tests

- 4 new unit tests in `src/ui/app.rs` (`tests::test_startup_buffer_*`)
- Full suite: 594 unit + integration tests passing

## Quality

- `cargo fmt` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅