### PR TITLE
chore(skills): prefer --body-file over here-string for gh issue/pr create

### DIFF
--- a/.github/skills/create-issue/SKILL.md
+++ b/.github/skills/create-issue/SKILL.md
@@ -120,19 +120,23 @@ Always verify before writing:
 
 ### 6. Create the issue
 
-**Always use a PowerShell here-string for the body** — backtick is PowerShell's escape character and any backtick-quoted code in markdown will corrupt or crash if passed as an inline string literal.
+**Always write the body to a temporary `.md` file and pass it via `--body-file`.** Inline `--body $body` with PowerShell here-strings is brittle: backticks (used liberally in markdown for code), unclosed `'@` markers, and `$variable` expansion in double-quoted strings all corrupt or crash the call. A file is also easier to draft, review, and re-use.
 
 ```powershell
-# Single-quoted here-string: backticks, $vars, and quotes are all literal.
-# The closing '@ MUST be at column 0 (no leading spaces).
-$body = @'
+# Draft the body in a temp file. Use Out-File -Encoding utf8 so multi-byte
+# characters (em-dashes, smart quotes, accented names) survive.
+$bodyPath = New-TemporaryFile | Rename-Item -NewName { $_.Name + '.md' } -PassThru
+@'
 ## Summary
 
-<paste your drafted body here>
-'@
+<paste your drafted body here — backticks, $vars, and quotes are all literal>
+'@ | Out-File -FilePath $bodyPath -Encoding utf8
 
-gh issue create --title "[Feature] Your title" --body $body
+gh issue create --title "[Feature] Your title" --body-file $bodyPath
+Remove-Item $bodyPath
 ```
+
+If you prefer, write the body with the `create` tool to a path under your session workspace (e.g. `C:\Users\<you>\.copilot\session-state\<sid>\files\issue-body.md`) — that file will already exist on disk and persists across checkpoints, which is useful when iterating on a draft.
 
 ### 7. Apply labels
 

--- a/.github/skills/work-on-issue/SKILL.md
+++ b/.github/skills/work-on-issue/SKILL.md
@@ -74,12 +74,13 @@ Closes #N"
 git push origin feat/issue-{N}-short-description
 ```
 
-Then create the PR. **Always use a PowerShell here-string for the body** — backtick is PowerShell's escape character, so any backtick-quoted code in a markdown body will corrupt or crash if passed as an inline string literal.
+Then create the PR. **Always write the body to a temporary `.md` file and pass it via `--body-file`.** Inline `--body $body` with PowerShell here-strings is brittle: backticks (used liberally in markdown for code), unclosed `'@` markers, and `$variable` expansion in double-quoted strings all corrupt or crash the call. A file is also easier to draft, review, and re-use.
 
 ```powershell
-# Single-quoted here-string: backticks, $vars, and quotes are all literal.
-# The closing '@ MUST be at column 0 (no leading spaces).
-$body = @'
+# Draft the body in a temp file. Use Out-File -Encoding utf8 so multi-byte
+# characters (em-dashes, smart quotes, accented names) survive.
+$bodyPath = New-TemporaryFile | Rename-Item -NewName { $_.Name + '.md' } -PassThru
+@'
 ## Summary
 
 Closes #N — one-paragraph description.
@@ -102,10 +103,13 @@ Closes #N — one-paragraph description.
 - `cargo fmt` ✅
 - `cargo clippy -- -D warnings` ✅
 - `cargo test` ✅
-'@
+'@ | Out-File -FilePath $bodyPath -Encoding utf8
 
-gh pr create --title "feat(scope): description" --body $body --base main
+gh pr create --title "feat(scope): description" --body-file $bodyPath --base main
+Remove-Item $bodyPath
 ```
+
+If you prefer, write the body with the `create` tool to a path under your session workspace (e.g. `C:\Users\<you>\.copilot\session-state\<sid>\files\pr-body.md`) — that file will already exist on disk and persists across checkpoints, which is useful when iterating on a draft.
 
 PR requirements:
 - Title in conventional commit format (`feat(scope): description`)


### PR DESCRIPTION
## Summary

Updates the `create-issue` and `work-on-issue` skills to prescribe the file-based `--body-file` approach for `gh issue create` / `gh pr create`, replacing the previous "always use a PowerShell here-string with `--body`" guidance.

The here-string approach is brittle: backticks (heavily used in markdown for inline code) are PowerShell's escape character, unclosed `'@` markers crash the call, and `$variable` expansion in double-quoted strings can corrupt content. Filing #220 and #221 in this session reinforced this — the user explicitly asked for file-based bodies.

## Changes

- `.github/skills/create-issue/SKILL.md`: Step 6 rewritten to use `New-TemporaryFile` + `Out-File -Encoding utf8` + `--body-file`. Adds an alternative tip about drafting in the session workspace.
- `.github/skills/work-on-issue/SKILL.md`: PR-creation block in step 7 rewritten with the same `--body-file` pattern, preserving the PR body template.

No other skills referenced `--body $body` or here-string body construction (verified via `grep`).

## Manual Testing

N/A — documentation-only change to skill files. The next session that invokes either skill will see the updated guidance.

## Quality

Documentation-only; no code paths affected.
