### PR TITLE
refactor(sanitize): consolidate sanitize_filename and centralize 140-byte cap

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,6 +30,17 @@ pub mod filesystem {
     /// Maximum filename length (cross-platform safe)
     pub const MAX_FILENAME_LENGTH: usize = 255;
 
+    /// Safety cap on sanitized filename byte length, used by
+    /// [`crate::download::sanitize::sanitize_filename`].
+    ///
+    /// Distinct from [`MAX_FILENAME_LENGTH`] (the absolute filesystem max):
+    /// this lower cap leaves headroom for extensions (`.mp3`), disambiguators
+    /// (`-2`, `-3`), and platform path-length overhead. Most modern
+    /// filesystems allow 255 bytes per filename, but Windows enforces
+    /// MAX_PATH (260 chars) for full paths and some sync targets (FAT32 USB
+    /// drives, MP3 players) have stricter caps.
+    pub const MAX_FILENAME_BYTES: usize = 140;
+
     /// Maximum path length (varies by platform, this is a safe minimum)
     pub const MAX_PATH_LENGTH: usize = 4096;
 
@@ -312,6 +323,8 @@ mod tests {
         use super::filesystem;
 
         const { assert!(filesystem::MAX_FILENAME_LENGTH == 255) }; // Cross-platform standard
+        const { assert!(filesystem::MAX_FILENAME_BYTES > 0) };
+        const { assert!(filesystem::MAX_FILENAME_BYTES < filesystem::MAX_FILENAME_LENGTH) };
         const { assert!(filesystem::MAX_PATH_LENGTH >= 4096) };
 
         #[cfg(unix)]

--- a/src/download/sanitize.rs
+++ b/src/download/sanitize.rs
@@ -14,7 +14,14 @@
 //! * Latin-1 / Latin Extended accented characters → ASCII equivalents
 //! * Misc symbols (`&` → `and`, `@` → `at`, etc.)
 //! * Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`)
-//! * Length cap of 140 characters with UTF-8 boundary safety
+//! * Length cap of [`MAX_FILENAME_BYTES`] bytes with UTF-8 boundary safety
+//!
+//! This module is the canonical filename sanitizer for any file written
+//! to the local filesystem (downloads, sync targets, device-side names).
+//! For playlist *directory* names with different rules (no Unicode folding,
+//! 100-char cap), use [`crate::utils::validation::sanitize_playlist_name`].
+
+use crate::constants::filesystem::MAX_FILENAME_BYTES;
 
 /// Comprehensive cross-platform filename sanitization.
 ///
@@ -135,13 +142,13 @@ pub fn sanitize_filename(input: &str, is_folder: bool) -> String {
         };
     }
 
-    // Step 6: Enforce length limits (140 chars for safety across all systems)
-    if final_name.len() > 140 {
+    // Step 6: Enforce length limit (see `MAX_FILENAME_BYTES` for rationale).
+    if final_name.len() > MAX_FILENAME_BYTES {
         // Try to truncate at word boundary
-        if let Some(last_space) = final_name[..140].rfind(' ') {
+        if let Some(last_space) = final_name[..MAX_FILENAME_BYTES].rfind(' ') {
             final_name.truncate(last_space);
         } else {
-            final_name.truncate(140);
+            final_name.truncate(MAX_FILENAME_BYTES);
         }
 
         // Ensure we didn't cut off in the middle of a UTF-8 character
@@ -210,5 +217,24 @@ mod tests {
     #[test]
     fn test_unicode_accents_folded() {
         assert_eq!(sanitize_filename("Café", false), "Cafe");
+    }
+
+    #[test]
+    fn test_length_cap_respects_max_filename_bytes() {
+        let long = "a".repeat(MAX_FILENAME_BYTES * 2);
+        let out = sanitize_filename(&long, false);
+        assert!(out.len() <= MAX_FILENAME_BYTES);
+    }
+
+    #[test]
+    fn test_length_cap_truncates_at_word_boundary() {
+        // Build an input with a space just below the cap so the truncation
+        // logic prefers the word boundary.
+        let prefix = "word ".repeat(MAX_FILENAME_BYTES / 5);
+        let input = format!("{prefix}extra-very-long-tail-segment");
+        let out = sanitize_filename(&input, false);
+        assert!(out.len() <= MAX_FILENAME_BYTES);
+        // Should not end mid-word (no trailing partial "tail-segment")
+        assert!(!out.ends_with("segment"));
     }
 }

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -33,21 +33,20 @@ pub fn is_valid_podcast_title(title: &str) -> bool {
     !title.trim().is_empty() && title.len() <= 200
 }
 
-/// Clean and validate a filename for safe filesystem usage
-pub fn sanitize_filename(filename: &str) -> String {
-    // Remove or replace characters that are problematic in filenames
-    let invalid_chars = ['<', '>', ':', '"', '|', '?', '*', '/', '\\'];
-    let mut sanitized = filename.to_string();
-
-    for invalid_char in invalid_chars {
-        sanitized = sanitized.replace(invalid_char, "_");
-    }
-
-    // Trim whitespace and limit length
-    sanitized.trim().chars().take(255).collect()
-}
+// NOTE: A previous `sanitize_filename` helper lived here but was unused
+// and superseded by [`crate::download::sanitize::sanitize_filename`], the
+// canonical cross-platform sanitizer for any file written to disk.
+// Use that for download paths, sync targets, and device-side filenames.
+// Use [`sanitize_playlist_name`] (below) only for playlist directory names,
+// which have a distinct contract (100-char cap, underscore replacement,
+// no Unicode folding).
 
 /// Sanitize playlist names for safe filesystem directory usage.
+///
+/// Distinct from [`crate::download::sanitize::sanitize_filename`]: this
+/// helper is tailored for playlist *directories* (shorter cap, simpler
+/// replacement strategy, no Unicode folding). For audio file names, use
+/// the download sanitizer instead.
 pub fn sanitize_playlist_name(name: &str) -> String {
     let trimmed = name.trim();
     if trimmed.is_empty() {
@@ -122,16 +121,6 @@ mod tests {
 
         assert!(is_valid_podcast_title("Valid Podcast"));
         assert!(!is_valid_podcast_title(""));
-    }
-
-    #[test]
-    fn test_filename_sanitization() {
-        assert_eq!(
-            sanitize_filename("Normal Filename.mp3"),
-            "Normal Filename.mp3"
-        );
-        assert_eq!(sanitize_filename("File<>:Name|?.mp3"), "File___Name__.mp3");
-        assert_eq!(sanitize_filename("  Trimmed  "), "Trimmed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Combined cleanup of two PR #216 follow-up issues that touch the same module.

- **Closes #218** — `utils::validation::sanitize_filename` was a simpler duplicate of `download::sanitize::sanitize_filename` with **no remaining call sites** (verified via grep). Removed the function and its test. Added doc comments to `sanitize_playlist_name` (which IS used by `playlist::file_manager` and `storage::json`) and a marker note in `validation.rs` steering future contributors to the canonical sanitizer for any filesystem-bound name.
- **Closes #217** — Added `constants::filesystem::MAX_FILENAME_BYTES = 140` with a doc comment explaining its relationship to the existing `MAX_FILENAME_LENGTH = 255` (absolute filesystem cap vs safety cap leaving headroom for extensions, disambiguators, and platform overhead). Replaced all three hardcoded `140` literals in `download/sanitize.rs` with the constant.

The two issues are combined here because they touch the same file (`download/sanitize.rs`) and share a single review context (both deferred from PR #216). Splitting would mean two PRs that step on the same lines.

## Changes

- `src/constants.rs`: add `filesystem::MAX_FILENAME_BYTES` constant + validation in `test_filesystem_constants`.
- `src/download/sanitize.rs`: import the constant, replace three `140` literals, update module-level doc, add two new tests covering the cap and word-boundary truncation.
- `src/utils/validation.rs`: remove unused `sanitize_filename` and its test, add steering doc for `sanitize_playlist_name`.

## Manual Testing

N/A — pure internal refactor with no observable behavior change. All existing sanitization behavior is preserved (same constant value, same algorithm). Coverage:

- The `MAX_FILENAME_BYTES` value (140) is identical to the previous literal.
- Two new unit tests in `download::sanitize::tests` assert that the cap is respected and that word-boundary truncation works.
- `test_filesystem_constants` now asserts `MAX_FILENAME_BYTES > 0` and `< MAX_FILENAME_LENGTH`.
- All 651 lib tests + integration tests pass.

## Tests

- 2 new unit tests in `src/download/sanitize.rs` (length cap, word boundary)
- Constant validation extended in `src/constants.rs`

## Quality

- `cargo fmt` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (651 lib tests + integration tests pass)
