### PR TITLE
fix(ci): auto-sync winget-pkgs fork before wingetcreate submit

### DIFF
--- a/.github/workflows/post-release-version-sync.yml
+++ b/.github/workflows/post-release-version-sync.yml
@@ -98,6 +98,26 @@ jobs:
             Write-Host "Nothing to commit — version already in sync with ${{ steps.version.outputs.VERSION }}"
           }
 
+      - name: Sync winget-pkgs fork with upstream
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
+        shell: pwsh
+        run: |
+          # Fast-forward lqdev/winget-pkgs:master from microsoft/winget-pkgs:master
+          # before submitting. wingetcreate's internal sync attempt fails closed when
+          # the fork has drifted between releases (~1 month of upstream commits is
+          # enough), aborting the submit and leaving the package half-released.
+          # The merge-upstream API is idempotent: returns merge_type=none if already
+          # in sync, fast-forward if behind, and conflict (error) if the fork has
+          # local changes (which it should never have for a release-bot fork).
+          # See issue #244 / run 25892737496.
+          Write-Host "Fast-forwarding lqdev/winget-pkgs:master from microsoft/winget-pkgs:master..."
+          gh api -X POST repos/lqdev/winget-pkgs/merge-upstream -f branch=master
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Fork sync failed; wingetcreate submit will not succeed until lqdev/winget-pkgs:master is reconciled with microsoft/winget-pkgs:master."
+            exit 1
+          }
+
       - name: Submit to winget-pkgs
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release automation: winget submit no longer fails when the maintainer's fork has drifted** — `post-release-version-sync.yml` now fast-forwards `lqdev/winget-pkgs:master` from `microsoft/winget-pkgs:master` via the GitHub `merge-upstream` API immediately before invoking `wingetcreate submit`. `wingetcreate`'s internal sync fails closed when the fork has accumulated upstream commits (typical between releases — the v1.13.0 submission failed after ~1 month of drift), aborting the submit and leaving the package half-released (code shipped, winget catalog stale). The new step is idempotent (no-op when already in sync), fails loudly on genuine conflicts, and uses the existing `WINGET_SUBMIT_TOKEN` secret. `docs/WINGET_PUBLISHING.md` updated with the recovery procedure for the rare case manual intervention is still needed. Closes #244.
+
 ---
 
 ## [1.13.0] - 2026-05-14

--- a/docs/WINGET_PUBLISHING.md
+++ b/docs/WINGET_PUBLISHING.md
@@ -108,8 +108,18 @@ A GitHub Actions workflow at `.github/workflows/post-release-version-sync.yml` a
 1. Updates `Cargo.toml` version to match the release tag
 2. Runs `wingetcreate update` to generate new manifests
 3. Commits and pushes both changes to `main`
+4. Fast-forwards `lqdev/winget-pkgs:master` from `microsoft/winget-pkgs:master` (via the GitHub `merge-upstream` API) so the maintainer's fork is current
+5. Submits the new manifest to `microsoft/winget-pkgs` via `wingetcreate submit`
 
 **Prerequisite**: `lqdev.PodcastTUI` must be submitted to and accepted in `microsoft/winget-pkgs` before the manifest generation step will succeed. Until then, use the manual post-release checklist below.
+
+**Fork-sync note**: Step 4 was added after the v1.13.0 release failed to submit because the maintainer's fork had drifted ~1 month behind upstream (issue #244). `wingetcreate` fails closed when its internal sync attempt errors. With the explicit pre-sync, the only manual recovery needed is for genuine conflicts (which should never occur on a release-bot fork that holds no local changes). If recovery is ever needed, run:
+
+```bash
+gh api -X POST repos/lqdev/winget-pkgs/merge-upstream -f branch=master
+```
+
+then re-run the failed workflow job.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit fork-sync step to `post-release-version-sync.yml` immediately before `wingetcreate submit`, fixing the failure mode that left v1.13.0's winget submission stuck until manually unblocked.

Closes #244.

## Why

`wingetcreate submit` opens a PR against `microsoft/winget-pkgs:master` from a feature branch on the maintainer's `lqdev/winget-pkgs` fork. Internally it fast-forwards the fork's `master` from upstream first, but **fails closed** if that sync errors for any reason. Over ~1 month between releases the fork accumulates enough upstream commits that `wingetcreate`'s sync attempt aborted v1.13.0's submit with:

> The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.

The release published, the local `manifests/` commit landed, but the upstream PR was never opened. Manual recovery (`gh api -X POST repos/lqdev/winget-pkgs/merge-upstream -f branch=master`) + a workflow re-run cleared it for v1.13.0, but this is the second silent half-release-class incident and was clearly going to recur every release.

Run that surfaced it: https://github.com/lqdev/podcast-tui/actions/runs/25892737496

## What changed

### `.github/workflows/post-release-version-sync.yml`

New step **Sync winget-pkgs fork with upstream**, inserted between *Commit and push version sync* and *Submit to winget-pkgs*:

```yaml
- name: Sync winget-pkgs fork with upstream
  env:
    GH_TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
  shell: pwsh
  run: |
    Write-Host "Fast-forwarding lqdev/winget-pkgs:master from microsoft/winget-pkgs:master..."
    gh api -X POST repos/lqdev/winget-pkgs/merge-upstream -f branch=master
    if ($LASTEXITCODE -ne 0) {
      Write-Error "Fork sync failed; wingetcreate submit will not succeed until lqdev/winget-pkgs:master is reconciled with microsoft/winget-pkgs:master."
      exit 1
    }
```

### Design choices

- **Hard fail, not warn.** If the explicit sync fails, `wingetcreate`'s internal sync would also fail. Hard-failing here gives a clearer cause line in the workflow log than the cryptic upstream error.
- **No conditional skip.** `merge-upstream` is idempotent (returns `merge_type: none` when already in sync), so running it unconditionally is one cheap API call and zero risk.
- **Reuses `WINGET_SUBMIT_TOKEN`.** Already has the `contents: write` scope on the fork that `merge-upstream` requires.
- **Hardcoded `lqdev/winget-pkgs`.** Matches existing hardcoding throughout the workflow (`lqdev.PodcastTUI`, etc). Both names move together if the project is ever forked.

### `docs/WINGET_PUBLISHING.md`

- *Post-Release Version Sync Workflow* section updated to list the new step (4) and the submission step (5) explicitly.
- New *Fork-sync note* documents the recovery procedure for the unlikely case of genuine fork conflicts.

### `CHANGELOG.md`

New `[Unreleased] → Fixed` entry describing the issue and fix.

## Testing

- YAML parses cleanly (`ConvertFrom-Yaml`).
- Step list verified in correct order:
  ```
  Checkout code → Extract version from tag → Update Cargo.toml version
  → Install wingetcreate → Generate winget manifests → Commit and push version sync
  → Sync winget-pkgs fork with upstream → Submit to winget-pkgs
  ```
- The `merge-upstream` API call has been validated end-to-end during the v1.13.0 manual recovery — same syntax, same token, same fork. Returned `{"merge_type": "fast-forward", "base_branch": "microsoft:master"}`.
- Full end-to-end validation of the new step will happen organically on the next release; nothing else exercises this workflow.

## Scope

CI/CD only — no application code changes, no test changes.
