### PR TITLE
fix(release): keep Cargo.lock version in sync with Cargo.toml

### DIFF
--- a/.github/skills/prepare-release/SKILL.md
+++ b/.github/skills/prepare-release/SKILL.md
@@ -67,6 +67,14 @@ version = "X.Y.Z"
 
 > **Note**: The `post-release-version-sync.yml` workflow also updates this after publishing, but setting it locally ensures `cargo build --version` output is correct for verification.
 
+Then sync `Cargo.lock` so its `podcast-tui` entry matches (the lockfile is tracked in git and must never drift from `Cargo.toml`):
+
+```powershell
+cargo update -p podcast-tui --precise X.Y.Z
+```
+
+> **Why this matters**: `release.yml` keys its build cache on `hashFiles('**/Cargo.lock')`. If the lockfile version never changes, the cache key is identical across releases and a stale cross-version `target/` can be served, embedding the wrong `CARGO_PKG_VERSION` into the binary. Always commit the updated `Cargo.lock` alongside `Cargo.toml`.
+
 ### 4. Run full verification
 
 ```powershell
@@ -82,11 +90,11 @@ All three must pass cleanly before tagging. The `test_opml_local_file` integrati
 ### 5. Commit the release prep
 
 ```bash
-git add Cargo.toml CHANGELOG.md
+git add Cargo.toml Cargo.lock CHANGELOG.md
 git commit -m "chore: prepare release vX.Y.Z
 
 - Finalize CHANGELOG.md for vX.Y.Z
-- Update Cargo.toml version to X.Y.Z
+- Update Cargo.toml and Cargo.lock version to X.Y.Z
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
@@ -118,8 +126,9 @@ After CI completes (~10 minutes):
 
 The `post-release-version-sync.yml` workflow triggers **automatically** when the GitHub Release is published (triggered by `release: types: [published]`, not by the tag push directly). It:
 1. Updates `Cargo.toml` version on `main` (no-op if you already set it in step 3)
-2. Generates winget manifests under `manifests/l/lqdev/PodcastTUI/<version>/`
-3. Commits and pushes both to `main`
+2. Syncs `Cargo.lock`'s `podcast-tui` entry to match (no-op if already in sync)
+3. Generates winget manifests under `manifests/l/lqdev/PodcastTUI/<version>/`
+4. Commits and pushes all three to `main`
 
 Monitor it:
 ```powershell
@@ -142,7 +151,7 @@ git push origin vX.Y.Z
   └─► release.yml (tag push: v*)
         └─► builds binaries + creates GitHub Release (published)
               └─► post-release-version-sync.yml (release: published)
-                    └─► updates Cargo.toml + generates winget manifests
+                    └─► updates Cargo.toml + Cargo.lock + generates winget manifests
 ```
 
 ## What NOT to do

--- a/.github/workflows/post-release-version-sync.yml
+++ b/.github/workflows/post-release-version-sync.yml
@@ -48,6 +48,20 @@ jobs:
           Write-Host "Updated Cargo.toml to version ${{ steps.version.outputs.VERSION }}"
           Get-Content Cargo.toml | Select-Object -First 5
 
+      - name: Sync Cargo.lock version
+        shell: pwsh
+        run: |
+          # Keep Cargo.lock's podcast-tui entry in lockstep with Cargo.toml so the
+          # tree on main stays internally consistent (AGENTS.md: "Cargo.lock is
+          # tracked in git — always commit changes to it"). cargo is preinstalled on
+          # the windows-latest runner.
+          cargo update -p podcast-tui --precise ${{ steps.version.outputs.VERSION }}
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "ERROR: Failed to sync Cargo.lock to ${{ steps.version.outputs.VERSION }}"
+            exit 1
+          }
+          Write-Host "Synced Cargo.lock to version ${{ steps.version.outputs.VERSION }}"
+
       - name: Install wingetcreate
         shell: pwsh
         run: |
@@ -85,7 +99,7 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml manifests/
+          git add Cargo.toml Cargo.lock manifests/
           git diff --cached --stat
           # Only commit and push if there are staged changes.
           # This prevents workflow failure when the version was already

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,11 @@ jobs:
           fi
           
           echo "✓ Version successfully updated to $VERSION"
+
+          # Keep Cargo.lock in sync so the embedded CARGO_PKG_VERSION matches and
+          # the build cache key (hashFiles('**/Cargo.lock')) changes per release.
+          cargo update -p podcast-tui --precise "$VERSION"
+          echo "✓ Cargo.lock synced to $VERSION"
       
       - name: Install build dependencies
         run: |
@@ -183,6 +188,15 @@ jobs:
           }
           
           Write-Host "✓ Version successfully updated to $version" -ForegroundColor Green
+
+          # Keep Cargo.lock in sync so the embedded CARGO_PKG_VERSION matches and
+          # the build cache key (hashFiles('**/Cargo.lock')) changes per release.
+          cargo update -p podcast-tui --precise $version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "ERROR: Failed to sync Cargo.lock to $version"
+            exit 1
+          }
+          Write-Host "✓ Cargo.lock synced to $version" -ForegroundColor Green
       
       - name: Install build dependencies
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release automation now keeps `Cargo.lock` in sync with `Cargo.toml`** — At tag `v1.14.0` the committed `Cargo.lock` still pinned `podcast-tui` to `1.13.0` even though `Cargo.toml` was bumped to `1.14.0`. The release pipeline bumped only `Cargo.toml` and never the lockfile, leaving the tree internally inconsistent (violating the tracked-lockfile rule in `AGENTS.md`). Because `release.yml` keys its build cache on `hashFiles('**/Cargo.lock')`, an unchanging lockfile produces an identical cache key across versions, risking a stale cross-version `target/` that embeds the wrong `CARGO_PKG_VERSION` into the binary. The fix: `release.yml` (both the Linux and Windows update-version steps), `post-release-version-sync.yml`, and the `prepare-release` skill now run `cargo update -p podcast-tui --precise <version>` after bumping `Cargo.toml` and commit `Cargo.lock` alongside it. The lockfile on `main` is corrected to `1.14.0` in this change. `docs/WINGET_PUBLISHING.md` gains a Troubleshooting section explaining the separate, local PATH-shadowing cause of a stale `podcast-tui --version` after a winget upgrade. Closes #254.
+
 ---
 
 ## [1.14.0] - 2026-05-14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "podcast-tui"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/WINGET_PUBLISHING.md
+++ b/docs/WINGET_PUBLISHING.md
@@ -322,6 +322,48 @@ wingetcreate submit manifests\l\lqdev\PodcastTUI\<VER> --token <PAT>
 
 ---
 
+## Troubleshooting
+
+### `podcast-tui --version` reports an older version than `winget list`
+
+**Symptom**: `winget list --id lqdev.PodcastTUI` shows the new version (e.g. `1.14.0`),
+but running `podcast-tui --version` prints an older one (e.g. `1.13.0`).
+
+**Cause**: PATH shadowing. A leftover **non-winget** install of `podcast-tui.exe` exists
+at `%LOCALAPPDATA%\Programs\podcast-tui\` (a manual/older install location), and that
+folder sits **earlier on PATH** than winget's managed copy under
+`%LOCALAPPDATA%\Microsoft\WinGet\Packages\lqdev.PodcastTUI_…\`. The shell resolves
+`podcast-tui` to the first match, so the stale binary wins. winget never touches the
+non-winget install, so upgrading the package doesn't replace it.
+
+**Fix** (either approach):
+
+```powershell
+# Option A — remove the stale shadow install
+# 1. Delete the leftover folder
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Programs\podcast-tui"
+# 2. Remove that path from the User PATH (Settings → Edit environment variables),
+#    then open a fresh terminal.
+
+# Option B — reinstall cleanly via winget
+winget uninstall lqdev.PodcastTUI
+winget install  lqdev.PodcastTUI
+```
+
+Open a **new** shell afterward and confirm:
+
+```powershell
+where.exe podcast-tui      # should list only the WinGet\Packages path
+podcast-tui --version      # should match winget list
+```
+
+> **Note**: Since v1.14.0 the release automation also keeps `Cargo.lock` in lockstep
+> with `Cargo.toml`, so the embedded `CARGO_PKG_VERSION` in official builds is always
+> correct. A version mismatch on a winget install is therefore a local PATH issue, not a
+> build/release bug.
+
+---
+
 ## References
 
 - [wingetcreate documentation](https://github.com/microsoft/winget-create)


### PR DESCRIPTION
## Summary

Fixes a latent release-automation bug: the pipeline bumped `Cargo.toml` on each release but **never `Cargo.lock`**, so the lockfile drifted out of sync. At tag `v1.14.0`, `Cargo.toml = 1.14.0` but the committed `Cargo.lock` still pinned `podcast-tui` to `1.13.0`.

Closes #254. Part of #251.

## Why it matters

- Violates the tracked-lockfile rule in `AGENTS.md` ("Cargo.lock is tracked in git — always commit changes to it").
- `release.yml` keys its build cache on `hashFiles('**/Cargo.lock')`. An unchanging lockfile yields an **identical cache key across versions**, so a stale cross-version `target/` can be served and embed the wrong `CARGO_PKG_VERSION` into the binary.

## What changed

- **`Cargo.lock`** corrected to `1.14.0` on this branch so `main` becomes internally consistent now.
- **`.github/workflows/release.yml`** — both the Linux (bash) and Windows (pwsh) "Update version" steps now run `cargo update -p podcast-tui --precise <version>` immediately after the `Cargo.toml` bump.
- **`.github/workflows/post-release-version-sync.yml`** — new "Sync Cargo.lock version" step + `Cargo.lock` added to the `git add` so the post-release commit carries it.
- **`.github/skills/prepare-release/SKILL.md`** — documents the lockfile bump (`cargo update -p podcast-tui --precise X.Y.Z`) and stages `Cargo.lock` in the release commit.
- **`docs/WINGET_PUBLISHING.md`** — new Troubleshooting section for the *separate, local* cause of a stale `podcast-tui --version` after a winget upgrade: PATH-shadowing by a leftover non-winget install at `%LOCALAPPDATA%\Programs\podcast-tui`.
- **`CHANGELOG.md`** `[Unreleased]` Fixed entry.

## Note on the original report

The user's `podcast-tui --version` showing `1.13.0` after a winget `1.14.0` install is a **local PATH-shadowing issue**, not a release bug — the official v1.14.0 binary and winget's own copy both report `1.14.0` correctly. That's documented in the new Troubleshooting section; cleanup steps were provided separately. This PR fixes the genuine (latent) lockfile-sync bug found during that investigation.

## Validation

Workflow YAML edits reviewed for indentation/shell correctness (no local CI runner; end-to-end verified on the next real release). `cargo update` already applied locally and committed.
