### PR TITLE
chore(release): fail-fast token preflight + WINGET_SUBMIT_TOKEN rotation runbook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,40 @@ on:
         type: string
 
 jobs:
+  validate-release-token:
+    name: Validate release token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify WINGET_SUBMIT_TOKEN is valid
+        env:
+          TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
+        run: |
+          # Fail fast before the ~15-minute build matrix if the release PAT is
+          # missing or expired. release.yml publishes the GitHub Release with this
+          # token (so the `release: published` event cascades into
+          # post-release-version-sync.yml); an expired PAT otherwise surfaces only
+          # at the Create GitHub Release step, after all builds have already run.
+          if [ -z "$TOKEN" ]; then
+            echo "::error::WINGET_SUBMIT_TOKEN secret is empty or unset. Add a classic PAT (scope: public_repo) as the WINGET_SUBMIT_TOKEN repo secret, then re-run this workflow."
+            exit 1
+          fi
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)
+          if [ "$code" = "200" ]; then
+            echo "✓ WINGET_SUBMIT_TOKEN is valid."
+          elif [ "$code" = "401" ]; then
+            echo "::error::WINGET_SUBMIT_TOKEN returned 401 Bad credentials — the PAT is expired or revoked. Regenerate a classic PAT (scope: public_repo) at https://github.com/settings/tokens, update the WINGET_SUBMIT_TOKEN repo secret, then re-run this workflow. See docs/WINGET_PUBLISHING.md."
+            exit 1
+          else
+            echo "::error::WINGET_SUBMIT_TOKEN validation got unexpected HTTP $code from api.github.com/user. Verify the token and re-run."
+            exit 1
+          fi
+
   build-linux:
     name: Build Linux releases (${{ matrix.arch }})
+    needs: validate-release-token
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -117,6 +149,7 @@ jobs:
 
   build-windows:
     name: Build Windows releases
+    needs: validate-release-token
     runs-on: windows-latest
     
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release pipeline fails fast on an expired release token** — The `release.yml` workflow now runs a `validate-release-token` preflight job that verifies the `WINGET_SUBMIT_TOKEN` PAT against the GitHub API before the build matrix, and the Linux/Windows build jobs depend on it. Previously an expired PAT (the token used to publish the GitHub Release so the `release: published` event cascades into winget manifest generation) surfaced only at the **Create GitHub Release** step — after ~15 minutes of builds had already run — as an opaque `HttpError: Bad credentials`. The preflight now fails in ~5 seconds with an actionable message pointing at the rotation runbook. `docs/WINGET_PUBLISHING.md` gains a `WINGET_SUBMIT_TOKEN` section documenting the token's purpose, required scope (`public_repo`), expiry pitfall, and the rotate + `gh run rerun --failed` recovery procedure. Closes #262.
+
 ---
 
 ## [1.15.0] - 2026-06-04

--- a/docs/WINGET_PUBLISHING.md
+++ b/docs/WINGET_PUBLISHING.md
@@ -277,6 +277,8 @@ sha256sum podcast-tui-v1.9.0-windows-x86_64.zip
 
 ## GitHub Personal Access Token
 
+### `wingetcreate` token (local, manual submissions)
+
 The `wingetcreate submit` and `wingetcreate update --submit` commands require a GitHub PAT with the following scopes:
 
 - `public_repo` — to fork and create PRs on `winget-pkgs`
@@ -286,6 +288,27 @@ Generate a token at https://github.com/settings/tokens and pass it via `--token`
 ```powershell
 wingetcreate token --store <github-pat>
 ```
+
+### `WINGET_SUBMIT_TOKEN` repo secret (CI release automation)
+
+The release pipeline authenticates with a classic PAT stored as the **`WINGET_SUBMIT_TOKEN`** repository secret. It is referenced in five places: `release.yml` (publish the GitHub Release, open the nix-hashes PR) and `post-release-version-sync.yml` (fast-forward the winget-pkgs fork, `wingetcreate submit`).
+
+- **Scope**: `public_repo` is sufficient (this repo and `microsoft/winget-pkgs` are public).
+- **Why a PAT and not the built-in `GITHUB_TOKEN`**: a release created with the built-in token does **not** trigger other workflows. Publishing the release with a PAT makes the `release: published` event cascade into `post-release-version-sync.yml`, which generates the winget manifests. Switching to `GITHUB_TOKEN` would silently stop manifest generation.
+- **Expiry pitfall**: classic PATs expire. When the token lapses, the **Create GitHub Release** step fails with `HttpError: Bad credentials` (HTTP 401) — but only *after* the full ~15-minute build matrix has already run. A `validate-release-token` preflight job in `release.yml` now catches an empty/expired token in ~5 seconds and fails with an actionable message, so the build matrix is skipped. (A 401 means the token string was rejected — expired or revoked — not a permissions problem, which would be a 403.)
+
+#### Rotating the token
+
+1. Regenerate a **classic PAT** with the `public_repo` scope at https://github.com/settings/tokens. Set a **long expiry** (e.g. 1 year) or add a calendar reminder so it doesn't lapse mid-release.
+2. Update the repo secret — `Settings → Secrets and variables → Actions → WINGET_SUBMIT_TOKEN → Update`, or:
+   ```powershell
+   gh secret set WINGET_SUBMIT_TOKEN
+   ```
+3. **Recover a half-failed release** (builds succeeded, publish failed): secrets are read at run time, so a re-run picks up the new token and reuses the cached build artifacts (30-day retention) — no rebuild:
+   ```powershell
+   gh run rerun <run-id> --failed
+   ```
+   This re-runs the `create-release` job (publishing the release, which fires the `post-release-version-sync.yml` cascade) and its dependent `update-flake-hashes` job. If the artifacts have expired, do a full re-run (`gh run rerun <run-id>`) or delete and re-push the tag.
 
 ---
 


### PR DESCRIPTION
## Summary

Hardens the release pipeline against an expired `WINGET_SUBMIT_TOKEN` PAT — the exact failure that broke the v1.15.0 release (run 26996073876), where all builds succeeded but **Create GitHub Release** failed instantly with `HttpError: Bad credentials` (401) only after ~15 minutes of builds.

## Changes

- **`release.yml`**: new `validate-release-token` preflight job (ubuntu-latest) that checks the PAT against `https://api.github.com/user` before anything else. `build-linux` and `build-windows` now `needs: validate-release-token`. An empty or 401 token fails in ~5 seconds with an actionable `::error::` message instead of wasting the full build matrix.
- **`docs/WINGET_PUBLISHING.md`**: new `WINGET_SUBMIT_TOKEN` runbook subsection — purpose, why a PAT (the `release: published` cascade into `post-release-version-sync.yml`), required `public_repo` scope, expiry pitfall, and the rotate + `gh run rerun --failed` recovery steps.
- **`CHANGELOG.md`**: `[Unreleased]` › Changed entry.

## Why a PAT (not GITHUB_TOKEN)

A release published by the built-in `GITHUB_TOKEN` does **not** trigger downstream workflows. The PAT makes `release: published` cascade into winget manifest generation, so this PR keeps the PAT and just validates it early.

## Notes

- Ships in the **next** release; does not affect the already-cut v1.15.0.
- Workflow-only + docs change; no Rust touched.

Closes #262
