### PR TITLE
feat(sync): device profiles carry their own sync_path; remove inert match_path_contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Device profiles carry their own sync target (`sync_path`)** — Each entry in `device_profiles[]` may now set a `sync_path`. Activating a profile — via `:set-device-profile` or for the `active_device_profile` at startup — sets the Sync buffer's active sync target to that path, so switching profiles points the target at the right device every time. Manual selection still works and takes session-level precedence: pressing `p` to pick a directory or selecting a saved target overrides the active target without rewriting the profile, and re-running `:set-device-profile` snaps it back to the configured `sync_path`. If the configured path isn't currently available (device unplugged), it is still applied and a warning is shown. Documented in [`docs/DEVICE_PROFILES.md`](docs/DEVICE_PROFILES.md). Closes #264.
+
 ### Changed
 
 - **Release pipeline fails fast on an expired release token** — The `release.yml` workflow now runs a `validate-release-token` preflight job that verifies the `WINGET_SUBMIT_TOKEN` PAT against the GitHub API before the build matrix, and the Linux/Windows build jobs depend on it. Previously an expired PAT (the token used to publish the GitHub Release so the `release: published` event cascades into winget manifest generation) surfaced only at the **Create GitHub Release** step — after ~15 minutes of builds had already run — as an opaque `HttpError: Bad credentials`. The preflight now fails in ~5 seconds with an actionable message pointing at the rotation runbook. `docs/WINGET_PUBLISHING.md` gains a `WINGET_SUBMIT_TOKEN` section documenting the token's purpose, required scope (`public_repo`), expiry pitfall, and the rotate + `gh run rerun --failed` recovery procedure. Closes #262.
+
+### Removed
+
+- **`match_path_contains` device-profile field** — Removed the inert `match_path_contains` field from `DeviceProfile`. It was never wired to any selection logic (a placeholder for auto-selection) and is superseded by the explicit `sync_path`. Existing `config.json` files are unaffected — the leftover key is ignored on load. Part of #264.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Podcast TUI exposes three customization surfaces in `config.json`. See [`docs/KE
 
 - **Startup buffer** — set `ui.startup_buffer` to one of `help`, `podcast-list`, `downloads`, `sync`, `playlist-list`, `whats-new`, `now-playing` to control which buffer opens on launch. Default: `help`.
 - **Keybinding presets** — set `keybindings.preset` to `default`, `vim`, or `emacs`. Per-action overrides go under `keybindings.bindings`.
-- **Device profiles** — for MP3 players that show the literal filename (e.g. Innioasis Y1, generic USB DACs), define a profile under `device_profiles[]` with a `filename_template` and select it via `active_device_profile`. The local downloads directory is untouched; only the device-side filenames are rewritten during sync. The `:set-device-profile` minibuffer command switches profiles at runtime.
+- **Device profiles** — for MP3 players that show the literal filename (e.g. Innioasis Y1, generic USB DACs), define a profile under `device_profiles[]` with a `filename_template` and select it via `active_device_profile`. The local downloads directory is untouched; only the device-side filenames are rewritten during sync. Give a profile a `sync_path` and switching to it points the active sync target at that device automatically. The `:set-device-profile` minibuffer command switches profiles at runtime.
 
 The storage layer also caches all podcasts, episodes, and playlists in memory and persists the index to `cache_index.json`, making warm launches near-instant. Toggle with `storage.cache_enabled` (default `true`); rebuild with `:cache-rebuild`. See [`docs/STORAGE_DESIGN.md`](docs/STORAGE_DESIGN.md) for benchmark numbers.
 

--- a/docs/DEVICE_PROFILES.md
+++ b/docs/DEVICE_PROFILES.md
@@ -24,7 +24,7 @@ Add this to `~/.config/podcast-tui/config.json` (Linux) or
   "device_profiles": [
     {
       "name": "Innioasis Y1",
-      "match_path_contains": "INNIOASIS",
+      "sync_path": "E:\\Podcasts",
       "filename_template": "{podcast_short}/{track:03} - {title}.{ext}",
       "max_filename_length": 64,
       "ascii_only": true
@@ -35,8 +35,9 @@ Add this to `~/.config/podcast-tui/config.json` (Linux) or
 ```
 
 Restart the app, then open the Sync buffer (`F8`). The header shows
-`Active device profile: Innioasis Y1`. A dry-run (`d`) previews the
-renamed files; `s` syncs them.
+`Active device profile: Innioasis Y1` and the active sync target is set
+to the profile's `sync_path` (`E:\Podcasts` above). A dry-run (`d`)
+previews the renamed files; `s` syncs them.
 
 ## Schema
 
@@ -45,7 +46,7 @@ Each entry in `device_profiles` is a `DeviceProfile`:
 | Field                 | Type    | Default | Description                                                                                                                          |
 |-----------------------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `name`                | string  | —       | Human-readable identifier. Referenced by `active_device_profile`.                                                                    |
-| `match_path_contains` | string? | `null`  | Substring matched against the sync target path. Currently informational; auto-selection is not yet wired to it.                      |
+| `sync_path`           | string? | `null`  | Configured sync location for this device. When the profile is activated (via `:set-device-profile` or at startup) the Sync buffer's active target is set to this path. Applied even if the device is not currently connected (a warning is shown). Manual target selection (`p` / picking a saved target) still overrides it for the session without rewriting this field. Empty/whitespace is treated as unset. |
 | `filename_template`   | string  | —       | Template used to render the per-file device-side path. See [Token reference](#token-reference). Empty templates are rejected at sync time. |
 | `max_filename_length` | uint    | `128`   | Maximum **byte** length applied to **each path segment** of the rendered filename after substitution (UTF-8-aware). Both the podcast-folder segment and the filename segment are capped independently.                |
 | `ascii_only`          | bool    | `false` | If `true`, strip non-ASCII characters from each segment after sanitization. If a segment becomes empty, it is replaced with the literal `Podcast` (folder segment) or `Episode` (filename segment) so files are never nameless. |
@@ -146,6 +147,24 @@ header updates immediately, and the change is **persisted to
 `config.json`** so it survives the next restart. If saving fails (for
 example, because the file is read-only), an error message is shown but
 the in-memory switch still applies for the current session.
+
+### Sync target follows the profile
+
+If the activated profile has a `sync_path`, activating it **always** sets
+the Sync buffer's active sync target to that path — so switching to your
+FiiO profile points the target at the FiiO, switching to the Innioasis
+points it at the Innioasis, every time. This also applies at startup for
+the `active_device_profile`.
+
+You retain full manual control: while a profile is active you can still
+press `p` to pick a different directory, or `Enter` a saved target, to
+override the active target for the current session. A manual override
+does **not** rewrite the profile's `sync_path`; running
+`:set-device-profile` again snaps the target back to the configured path.
+
+If the configured `sync_path` isn't currently available (the device is
+unplugged), it is still set as the active target and a warning is shown —
+plug the device in and sync, or pick another target with `p`.
 
 ## Verifying before syncing
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -214,7 +214,7 @@ Press `:` (or `Shift+:`) to open the command prompt. Press `Tab` to autocomplete
 
 - `sync [path]` — Sync to device
 - `sync-dry-run [path]` — Preview sync without applying
-- `set-device-profile [name]` — Switch the active device profile and persist the change to `config.json`. Tab-completes against `device_profiles[].name` from `config.json`. Empty argument clears the active profile. If the save fails an error is shown but the in-memory switch still applies for the current session. See [`docs/DEVICE_PROFILES.md`](DEVICE_PROFILES.md).
+- `set-device-profile [name]` — Switch the active device profile and persist the change to `config.json`. Tab-completes against `device_profiles[].name` from `config.json`. Empty argument clears the active profile. If the profile has a `sync_path`, the active sync target is set to it (overriding any manual pick; an unavailable path still applies with a warning). If the save fails an error is shown but the in-memory switch still applies for the current session. See [`docs/DEVICE_PROFILES.md`](DEVICE_PROFILES.md).
 
 ### Storage Commands
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,7 +344,7 @@ impl Default for ScrobblingConfig {
 /// ```json
 /// {
 ///   "name": "Innioasis Y1",
-///   "match_path_contains": "INNIOASIS",
+///   "sync_path": "E:\\Podcasts",
 ///   "filename_template": "{podcast} - {episode_number:03} - {title}.{ext}",
 ///   "max_filename_length": 64,
 ///   "ascii_only": true,
@@ -356,11 +356,15 @@ pub struct DeviceProfile {
     /// Human-readable identifier for the profile. Referenced by
     /// [`Config::active_device_profile`].
     pub name: String,
-    /// Optional substring to match against the sync target path for future
-    /// auto-selection. Currently informational only — sync still uses
-    /// `active_device_profile` to choose a profile.
+    /// Optional configured sync location for this device. When the profile is
+    /// activated (via `:set-device-profile` or at startup), the Sync buffer's
+    /// active target is set to this path. An empty or whitespace-only value is
+    /// treated as unset. The path is applied even if it is not currently
+    /// available (e.g. the device is unplugged), with a warning surfaced to the
+    /// user. Manual target selection (`p` / picking a saved target) still
+    /// overrides the active target for the session without rewriting this field.
     #[serde(default)]
-    pub match_path_contains: Option<String>,
+    pub sync_path: Option<String>,
     /// Filename template containing literal text and substitution tokens.
     ///
     /// Validation is intentionally deferred to the template engine (#208) so
@@ -1230,7 +1234,7 @@ mod tests {
             device_profiles: vec![
                 DeviceProfile {
                     name: "Innioasis Y1".to_string(),
-                    match_path_contains: Some("INNIOASIS".to_string()),
+                    sync_path: Some("E:\\Podcasts".to_string()),
                     filename_template: "{podcast} - {episode_number:03} - {title}.{ext}"
                         .to_string(),
                     max_filename_length: 64,
@@ -1239,7 +1243,7 @@ mod tests {
                 },
                 DeviceProfile {
                     name: "Generic USB".to_string(),
-                    match_path_contains: None,
+                    sync_path: None,
                     filename_template: "{title}.{ext}".to_string(),
                     max_filename_length: 128,
                     ascii_only: false,
@@ -1303,7 +1307,7 @@ mod tests {
         assert_eq!(profile.max_filename_length, 128);
         assert!(!profile.ascii_only);
         assert!(profile.preserve_structure); // default_true
-        assert!(profile.match_path_contains.is_none());
+        assert!(profile.sync_path.is_none());
     }
 
     #[test]
@@ -1313,7 +1317,7 @@ mod tests {
             device_profiles: vec![
                 DeviceProfile {
                     name: "A".to_string(),
-                    match_path_contains: None,
+                    sync_path: None,
                     filename_template: "a.{ext}".to_string(),
                     max_filename_length: 128,
                     ascii_only: false,
@@ -1321,7 +1325,7 @@ mod tests {
                 },
                 DeviceProfile {
                     name: "B".to_string(),
-                    match_path_contains: None,
+                    sync_path: None,
                     filename_template: "b.{ext}".to_string(),
                     max_filename_length: 128,
                     ascii_only: false,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -66,6 +66,31 @@ fn resolve_startup_buffer_id(buffer_manager: &BufferManager, name: &str) -> Opti
     }
 }
 
+/// Apply the active device profile's configured `sync_path` (if any) to the
+/// Sync buffer's active target.
+///
+/// Returns `Some((path, available))` when the active profile has a non-empty
+/// `sync_path` that was applied — `available` reflects whether the path
+/// currently exists as a directory (an unavailable device, e.g. unplugged, is
+/// still applied). Returns `None` when there is no active profile or it has no
+/// `sync_path`, in which case the active target is left untouched.
+fn apply_profile_sync_target(
+    config: &Config,
+    buffer_manager: &mut BufferManager,
+) -> Option<(std::path::PathBuf, bool)> {
+    let sync_path = config
+        .active_device_profile()
+        .and_then(|p| p.sync_path.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)?;
+    let available = sync_path.is_dir();
+    if let Some(sync_buffer) = buffer_manager.get_sync_buffer_mut() {
+        sync_buffer.set_active_target(sync_path.clone());
+    }
+    Some((sync_path, available))
+}
+
 /// The main UI application
 pub struct UIApp {
     /// Configuration
@@ -308,6 +333,7 @@ impl UIApp {
                 config.active_device_profile().map(|p| p.name.clone()),
             );
         }
+        apply_profile_sync_target(&config, &mut buffer_manager);
         buffer_manager.create_playlist_list_buffer(playlist_manager.clone());
         buffer_manager.create_whats_new_buffer(
             subscription_manager.clone(),
@@ -647,6 +673,7 @@ impl UIApp {
                 self.config.active_device_profile().map(|p| p.name.clone()),
             );
         }
+        apply_profile_sync_target(&self.config, &mut self.buffer_manager);
         self.buffer_manager.create_whats_new_buffer(
             self.subscription_manager.clone(),
             self.download_manager.clone(),
@@ -3123,7 +3150,19 @@ impl UIApp {
             if let Some(sync_buffer) = self.buffer_manager.get_sync_buffer_mut() {
                 sync_buffer.set_active_device_profile_name(Some(trimmed.to_string()));
             }
-            self.show_message(format!("Active device profile: {}", trimmed));
+            match apply_profile_sync_target(&self.config, &mut self.buffer_manager) {
+                Some((path, true)) => self.show_message(format!(
+                    "Active device profile: {} (sync target: {})",
+                    trimmed,
+                    path.display()
+                )),
+                Some((path, false)) => self.show_message(format!(
+                    "Active device profile: {} (sync target {} is not currently available)",
+                    trimmed,
+                    path.display()
+                )),
+                None => self.show_message(format!("Active device profile: {}", trimmed)),
+            }
             let _ = self.persist_config();
         } else {
             self.show_error(format!("No device profile named '{}'", trimmed));
@@ -5841,7 +5880,7 @@ mod tests {
     fn sample_profile(name: &str) -> crate::config::DeviceProfile {
         crate::config::DeviceProfile {
             name: name.to_string(),
-            match_path_contains: None,
+            sync_path: None,
             filename_template: "{podcast}/{title}.{ext}".to_string(),
             max_filename_length: 128,
             ascii_only: false,
@@ -5917,6 +5956,101 @@ mod tests {
         assert!(cmds.iter().any(|c| c == "set-device-profile"));
         assert!(cmds.iter().any(|c| c == "set-device-profile Innioasis Y1"));
         assert!(cmds.iter().any(|c| c == "set-device-profile Generic"));
+    }
+
+    /// Helper: a device profile with a configured `sync_path`.
+    fn profile_with_path(name: &str, sync_path: &str) -> crate::config::DeviceProfile {
+        crate::config::DeviceProfile {
+            sync_path: Some(sync_path.to_string()),
+            ..sample_profile(name)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_device_profile_applies_sync_path_to_active_target() {
+        // An available (existing) sync_path is set as the active sync target.
+        let target = tempfile::TempDir::new().unwrap();
+        let target_path = target.path().to_path_buf();
+        let (mut app, _tmp) = make_app_with_device_profiles(
+            vec![profile_with_path("FiiO", &target_path.to_string_lossy())],
+            None,
+        )
+        .await;
+
+        app.set_device_profile_direct("FiiO");
+
+        let sync_buf = app.buffer_manager.get_sync_buffer_mut().unwrap();
+        assert_eq!(sync_buf.active_target(), Some(&target_path));
+    }
+
+    #[tokio::test]
+    async fn test_set_device_profile_without_sync_path_leaves_target_unchanged() {
+        // Switching to a profile with no sync_path must not touch the active
+        // target — a previously chosen target stays put.
+        let existing = tempfile::TempDir::new().unwrap();
+        let existing_path = existing.path().to_path_buf();
+        let (mut app, _tmp) =
+            make_app_with_device_profiles(vec![sample_profile("Generic")], None).await;
+        if let Some(buf) = app.buffer_manager.get_sync_buffer_mut() {
+            buf.set_active_target(existing_path.clone());
+        }
+
+        app.set_device_profile_direct("Generic");
+
+        let sync_buf = app.buffer_manager.get_sync_buffer_mut().unwrap();
+        assert_eq!(sync_buf.active_target(), Some(&existing_path));
+    }
+
+    #[tokio::test]
+    async fn test_set_device_profile_unavailable_sync_path_still_sets_target() {
+        // An unplugged device (path does not exist) is still applied as the
+        // active target so the user can plug in and sync.
+        let missing = if cfg!(windows) {
+            "Z:\\podcast-tui-does-not-exist"
+        } else {
+            "/podcast-tui/does/not/exist"
+        };
+        let (mut app, _tmp) =
+            make_app_with_device_profiles(vec![profile_with_path("FiiO", missing)], None).await;
+
+        app.set_device_profile_direct("FiiO");
+
+        let sync_buf = app.buffer_manager.get_sync_buffer_mut().unwrap();
+        assert_eq!(
+            sync_buf.active_target(),
+            Some(&std::path::PathBuf::from(missing))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_device_profile_resets_target_after_manual_override() {
+        // After a manual target override, re-running set-device-profile snaps
+        // the active target back to the profile's configured sync_path.
+        let configured = tempfile::TempDir::new().unwrap();
+        let configured_path = configured.path().to_path_buf();
+        let manual = tempfile::TempDir::new().unwrap();
+        let manual_path = manual.path().to_path_buf();
+        let (mut app, _tmp) = make_app_with_device_profiles(
+            vec![profile_with_path(
+                "FiiO",
+                &configured_path.to_string_lossy(),
+            )],
+            None,
+        )
+        .await;
+
+        app.set_device_profile_direct("FiiO");
+        // User manually picks a different directory for the session.
+        if let Some(buf) = app.buffer_manager.get_sync_buffer_mut() {
+            buf.set_active_target(manual_path.clone());
+            assert_eq!(buf.active_target(), Some(&manual_path));
+        }
+
+        // Re-applying the profile resets to the configured path.
+        app.set_device_profile_direct("FiiO");
+
+        let sync_buf = app.buffer_manager.get_sync_buffer_mut().unwrap();
+        assert_eq!(sync_buf.active_target(), Some(&configured_path));
     }
 
     // ---- persist_config tests (#223) -----------------------------------

--- a/tests/test_sync_with_device_profile.rs
+++ b/tests/test_sync_with_device_profile.rs
@@ -68,7 +68,7 @@ async fn make_podcast_with_episodes(
 fn make_profile(template: &str, ascii_only: bool, max: usize) -> DeviceProfile {
     DeviceProfile {
         name: "test-profile".to_string(),
-        match_path_contains: None,
+        sync_path: None,
         filename_template: template.to_string(),
         max_filename_length: max,
         ascii_only,
@@ -79,7 +79,7 @@ fn make_profile(template: &str, ascii_only: bool, max: usize) -> DeviceProfile {
 fn make_flat_profile(template: &str, ascii_only: bool, max: usize) -> DeviceProfile {
     DeviceProfile {
         name: "flat-test-profile".to_string(),
-        match_path_contains: None,
+        sync_path: None,
         filename_template: template.to_string(),
         max_filename_length: max,
         ascii_only,


### PR DESCRIPTION
## Summary

Device profiles can now carry their own **`sync_path`**. Activating a profile points the Sync buffer's active sync target at that device — so switching to your FiiO profile targets the FiiO, switching to the Innioasis targets the Innioasis, every time.

Closes #264.

## What changed

- **`src/config.rs`** — Added `sync_path: Option<String>` (`#[serde(default)]`) to `DeviceProfile`. **Removed** the inert `match_path_contains` field (it was never read by any logic — a placeholder for auto-selection that's now superseded by `sync_path`).
- **`src/ui/app.rs`** — New `apply_profile_sync_target` helper, called from `set_device_profile_direct` and the two startup buffer-creation sites. Switching to a profile with a `sync_path` sets the active sync target to it.

## Behavior

- **`:set-device-profile <name>` always re-applies** the profile's `sync_path` (and at startup for `active_device_profile`).
- **Manual selection keeps session-level precedence** — `p` (pick directory) or selecting a saved target still overrides the active target, and does **not** rewrite the profile's `sync_path`. Re-running `:set-device-profile` snaps back to the configured path.
- **Unavailable path (device unplugged)** is still applied, with a non-error heads-up message so the switch clearly succeeded.
- A profile with **no `sync_path`** leaves the active target unchanged.
- A profile switch does **not** bump a saved target's `use_count` (stays "real syncs only").
- No new command — `sync_path` is authored in `config.json`, like the rest of a profile.

## Compatibility

Existing `config.json` files are unaffected: `DeviceProfile` has no `deny_unknown_fields`, so a leftover `match_path_contains` key is ignored on load.

## Tests

New unit tests (all pass): switch applies the target; no-`sync_path` leaves it unchanged; an unavailable path still sets the target; a manual override followed by re-switch resets to the configured path; config round-trips `sync_path`. `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (708 lib tests) all clean.

## Docs

`docs/DEVICE_PROFILES.md` (schema row + worked example + a "Sync target follows the profile" section), `docs/KEYBINDINGS.md`, `README.md`, and `CHANGELOG.md`.
